### PR TITLE
fix: update @antv/scale dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@antv/dom-util": "^2.0.1",
     "@antv/g": "~3.5.0-beta.1",
     "@antv/path-util": "^2.0.0",
-    "@antv/scale": "~0.2.0",
+    "@antv/scale": "~0.3.0",
     "@antv/util": "~2.0.0",
     "tslib": "^1.10.0"
   },

--- a/src/trend/path.ts
+++ b/src/trend/path.ts
@@ -1,6 +1,5 @@
 import * as pathUtil from '@antv/path-util';
-import Category from '@antv/scale/lib/category';
-import Linear from '@antv/scale/lib/linear';
+import { Category, Linear } from '@antv/scale';
 import * as _ from '@antv/util';
 
 type Point = [number, number];


### PR DESCRIPTION
This PR update the @antv/scale dependency to ~0.3.0

Cause @antv/g2plot (last version) using following dependencies.
- @antv/scale~0.3.0
- @antv/gui~0.1.0 using @antv/scale~0.2.0

So when we use the @antv/scale~0.3.0, we have the following error
`ERROR in ./node_modules/@antv/gui/esm/trend/path.js
Module not found: Error: Can't resolve '@antv/scale/lib/category' in '/home/tcharlot/go/src/myapp/node_modules/@antv/gui/esm/trend'`
