### PR TITLE
fix: 升级 G 测试版 & 修复若干自定义组件方法

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,4 +1,5 @@
 window.gui = require('./src/index.ts');
 window.gCanvas = require('@antv/g-canvas');
+window.gSvg = require('@antv/g-svg');
 window.g = require('@antv/g');
 window.reactDom = require('react-dom');

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "GUI"
   ],
   "dependencies": {
-    "@antv/g": "^1.0.0-alpha.7",
-    "@antv/g-canvas": "^1.0.0-alpha.8",
-    "@antv/g-svg": "^1.0.0-alpha.8",
+    "@antv/g": "^1.0.0-alpha.8",
+    "@antv/g-canvas": "^1.0.0-alpha.9",
+    "@antv/g-svg": "^1.0.0-alpha.9",
     "@antv/path-util": "^2.0.9",
     "@antv/scale": "^0.4.3",
     "@antv/util": "^2.0.13",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "GUI"
   ],
   "dependencies": {
-    "@antv/g": "^1.0.0-alpha.4",
-    "@antv/g-canvas": "^1.0.0-alpha.5",
-    "@antv/g-svg": "^1.0.0-alpha.5",
+    "@antv/g": "^1.0.0-alpha.7",
+    "@antv/g-canvas": "^1.0.0-alpha.8",
+    "@antv/g-svg": "^1.0.0-alpha.8",
     "@antv/path-util": "^2.0.9",
     "@antv/scale": "^0.4.3",
     "@antv/util": "^2.0.13",

--- a/src/ui/button/index.ts
+++ b/src/ui/button/index.ts
@@ -1,9 +1,9 @@
-import { Rect, Text } from '@antv/g';
+import { Rect, Text, BaseStyleProps } from '@antv/g';
 import { deepMix, pick } from '@antv/util';
 import { GUI } from '../core/gui';
 import { getEllipsisText } from '../../util';
 import { SIZE_STYLE, TYPE_STYLE, DISABLED_STYLE } from './constant';
-import type { ShapeAttrs, DisplayObject } from '../../types';
+import type { DisplayObject } from '../../types';
 import type { ButtonAttrs, ButtonOptions } from './types';
 
 export type { ButtonAttrs, ButtonOptions };
@@ -144,9 +144,6 @@ export class Button extends GUI<ButtonAttrs> {
     this.appendChild(this.background);
     this.appendChild(this.textShape);
 
-    // 设置位置
-    this.translate(x, y);
-
     this.bindEvents(onClick);
   }
 
@@ -165,7 +162,7 @@ export class Button extends GUI<ButtonAttrs> {
   /**
    * 应用多个属性
    */
-  private applyAttrs(shape: 'textShape' | 'background', attrs: ShapeAttrs) {
+  private applyAttrs(shape: 'textShape' | 'background', attrs: BaseStyleProps) {
     Object.entries(attrs).forEach((attr) => {
       this[shape].attr(attr[0], attr[1]);
     });

--- a/src/ui/button/types.ts
+++ b/src/ui/button/types.ts
@@ -1,6 +1,6 @@
-import type { ShapeAttrs, ShapeCfg } from '../../types';
+import type { BaseStyleProps } from '../../types';
 
-export type ButtonAttrs = {
+export interface ButtonAttrs extends BaseStyleProps {
   x?: number;
   y?: number;
   /**
@@ -38,20 +38,20 @@ export type ButtonAttrs = {
   /**
    * 自定义文本样式
    */
-  textStyle?: ShapeAttrs;
+  textStyle?: BaseStyleProps;
   /**
    * 自定义按钮样式
    */
-  buttonStyle?: ShapeAttrs;
+  buttonStyle?: BaseStyleProps;
   /**
    * 自定义激活状态
    */
   hoverStyle?: {
-    textStyle: ShapeAttrs;
-    buttonStyle: ShapeAttrs;
+    textStyle: BaseStyleProps;
+    buttonStyle: BaseStyleProps;
   };
-};
+}
 
-export type ButtonOptions = ShapeCfg & {
+export type ButtonOptions = {
   attrs: ButtonAttrs;
 };

--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -1,4 +1,5 @@
 import { Group, Rect, Text } from '@antv/g';
+import type { TextStyleProps } from '@antv/g';
 import { clamp, deepMix, get, isUndefined } from '@antv/util';
 import { Rail } from './rail';
 import { Labels } from './labels';
@@ -10,7 +11,7 @@ import { toPrecision } from '../../util';
 import type { Pair } from '../slider/types';
 import type { MarkerAttrs } from '../marker';
 import type { ContinuousCfg, ContinuousOptions, IndicatorCfg } from './types';
-import type { DisplayObject, ShapeAttrs } from '../../types';
+import type { DisplayObject } from '../../types';
 
 export type { ContinuousOptions };
 
@@ -329,7 +330,7 @@ export class Continuous extends LegendBase<ContinuousCfg> {
   }
 
   // 获取Label属性
-  private getLabelsAttrs(): ShapeAttrs[] {
+  private getLabelsAttrs(): TextStyleProps[] {
     const { label } = this.attributes;
     // 不绘制label
     if (!label) {
@@ -337,7 +338,7 @@ export class Continuous extends LegendBase<ContinuousCfg> {
     }
     const { min, max, rail } = this.attributes;
     const { style, formatter, align } = label;
-    const attrs = [];
+    const attrs: TextStyleProps[] = [];
     // align为rail时仅显示min、max的label
     if (align === 'rail') {
       [min, max].forEach((value, idx) => {
@@ -503,12 +504,12 @@ export class Continuous extends LegendBase<ContinuousCfg> {
 
   private getRail(item?: string) {
     if (item === 'rail') {
-      return this.getElementById('railPathGroup');
+      return this.railShape.getRailPathGroup();
     }
     if (item === 'background') {
-      return this.getElementById('railBackgroundGroup');
+      return this.railShape.getBackgroundPathGroup();
     }
-    return this.getElementById('rail');
+    return this.railShape;
   }
 
   /**

--- a/src/ui/legend/rail.ts
+++ b/src/ui/legend/rail.ts
@@ -1,8 +1,6 @@
 import { isString, deepMix } from '@antv/util';
-import { CustomElement, Group, Path } from '@antv/g';
-import type { PathCommand } from '@antv/g-base';
+import { CustomElement, DisplayObjectConfig, Group, Path, PathCommand } from '@antv/g';
 import type { RailCfg as defaultCfg } from './types';
-import type { ShapeCfg } from '../../types';
 import { createTrapezoidRailPath, createRectRailPath, getValueOffset } from './utils';
 
 type RailAttrs = defaultCfg & {
@@ -14,14 +12,14 @@ type RailAttrs = defaultCfg & {
   orient?: 'horizontal' | 'vertical';
 };
 
-export class Rail extends CustomElement {
+export class Rail extends CustomElement<RailAttrs> {
   // 色板的path group
   private railPathGroup: Group;
 
   // 背景的path group
   private backgroundPathGroup: Group;
 
-  constructor({ attrs, ...rest }: ShapeCfg & { attrs: RailAttrs }) {
+  constructor({ attrs, ...rest }: DisplayObjectConfig<RailAttrs>) {
     super({ type: 'rail', attrs, ...rest });
     this.init();
   }
@@ -35,6 +33,14 @@ export class Rail extends CustomElement {
     // if (['start', 'end'].includes(name)) {
     //   this.updateSelection();
     // }
+  }
+
+  getRailPathGroup() {
+    return this.railPathGroup;
+  }
+
+  getBackgroundPathGroup() {
+    return this.backgroundPathGroup;
   }
 
   public init() {

--- a/src/ui/slider/handle.ts
+++ b/src/ui/slider/handle.ts
@@ -1,6 +1,5 @@
-import { CustomElement, Rect, Line } from '@antv/g';
+import { CustomElement, Rect, Line, DisplayObjectConfig } from '@antv/g';
 import { Marker } from '../marker';
-import type { ShapeCfg } from '../../types';
 
 type AttrsType = { [key: string]: any };
 type HandleCfg = AttrsType & {
@@ -8,15 +7,14 @@ type HandleCfg = AttrsType & {
   orient: string;
 };
 
-export class Handle extends CustomElement {
-  constructor({ attrs, ...rest }: ShapeCfg) {
-    super({ type: 'handle', attrs, ...rest });
-    const { type, orient, ...handleAttrs } = attrs;
+export class Handle extends CustomElement<HandleCfg> {
+  constructor(config: DisplayObjectConfig<HandleCfg>) {
+    super(config);
+    const { type, orient, ...handleAttrs } = config.style || {};
     this.render({ type, orient, handleAttrs });
   }
 
   public render(handleCfg: HandleCfg) {
-    this.removeChildren(true);
     const { type, orient, handleAttrs: attrs } = handleCfg;
 
     if (type === 'hide') {
@@ -81,7 +79,7 @@ export class Handle extends CustomElement {
     }
   }
 
-  attributeChangedCallback(name: string, value: any) {
+  attributeChangedCallback<Key extends keyof HandleCfg>(name: Key, value: any) {
     if (name === 'handleCfg') {
       this.render(value);
     }

--- a/src/ui/sparkline/index.ts
+++ b/src/ui/sparkline/index.ts
@@ -1,7 +1,7 @@
 import { Rect } from '@antv/g';
+import type { PathCommand } from '@antv/g';
 import { clone, deepMix, isNumber, isArray, isFunction } from '@antv/util';
 import { Linear, Band } from '@antv/scale';
-import { PathCommand } from '@antv/g-base';
 import { GUI } from '../core/gui';
 import { Lines } from './lines';
 import { Columns } from './columns';

--- a/src/ui/sparkline/lines.ts
+++ b/src/ui/sparkline/lines.ts
@@ -1,19 +1,18 @@
-import { CustomElement, Path } from '@antv/g';
-import type { ShapeCfg } from '../../types';
+import { CustomElement, DisplayObjectConfig, Path } from '@antv/g';
+import type { PathStyleProps } from '@antv/g';
 
-type AttrsType = { [key: string]: any };
-type LinesCfg = { linesAttrs: AttrsType[]; areasAttrs?: AttrsType[] };
+type LinesCfg = { linesAttrs?: PathStyleProps[]; areasAttrs?: PathStyleProps[] };
 
-export class Lines extends CustomElement {
-  constructor({ attrs, ...rest }: ShapeCfg) {
-    super({ type: 'lines', attrs, ...rest });
-    this.render(attrs.linesCfg);
+export class Lines extends CustomElement<{ linesCfg: LinesCfg }> {
+  constructor(config: DisplayObjectConfig<{ linesCfg: LinesCfg }>) {
+    super(config);
+    this.render(config.style?.linesCfg);
   }
 
-  public render(linesCfg: LinesCfg): void {
+  public render(linesCfg?: LinesCfg): void {
     this.removeChildren(true);
-    const { linesAttrs, areasAttrs } = linesCfg;
-    linesAttrs.forEach((cfg) => {
+    const { linesAttrs, areasAttrs } = linesCfg || {};
+    linesAttrs?.forEach((cfg) => {
       this.appendChild(
         new Path({
           name: 'line',


### PR DESCRIPTION
升级 G 最新测试版，修复以下 bug：
* Path 解析问题 https://github.com/antvis/g/issues/795
* 创建两个canvas时，无法创建canvas dom元素。示例： http://g-next.antv.vision/zh/examples/canvas/#dom-canvas
* 创建图形时，无法通过传入visibility属性为hidden使得图形不可见。
* 自定义元素添加到画布后，外界便无法查询其内部内容

其他新增 features：
* 动画 http://g-next.antv.vision/zh/docs/api/animation
* Clip http://g-next.antv.vision/zh/docs/api/basic/display-object#clippath