### PR TITLE
fix: 修复switch 问题, g 的 removeChild 方法传入 destroy = false 参数

### DIFF
--- a/examples/basic-ui/switch/demo/checked-switch.ts
+++ b/examples/basic-ui/switch/demo/checked-switch.ts
@@ -36,6 +36,6 @@ const button = new Button({
     },
   },
 });
-button.flag = true;
+button.flag = false;
 canvas.appendChild(button);
 canvas.appendChild(checkedSwitch);

--- a/examples/basic-ui/switch/demo/meta.json
+++ b/examples/basic-ui/switch/demo/meta.json
@@ -23,8 +23,8 @@
     {
       "filename": "checked-switch.ts",
       "title": {
-        "zh": "外部控制 开关",
-        "en": "External control switch"
+        "zh": "按钮控制 开关",
+        "en": "Push button control switch"
       },
       "screenshot": ""
     },

--- a/src/ui/switch/index.ts
+++ b/src/ui/switch/index.ts
@@ -261,7 +261,7 @@ export class Switch extends GUI<Required<SwitchCfg>> {
         // checked 控制这个有无
         (index === 0 ? this.checked : !this.checked)
           ? this.backgroundShape.appendChild(childrenShape)
-          : this.backgroundShape.removeChild(childrenShape);
+          : this.backgroundShape.removeChild(childrenShape, false);
 
         // 位置 为 开启 textSpacing, 关闭 整体width - 本身 width - textSpacing
         childrenShape.update({


### PR DESCRIPTION


`切换的时候，text 丢失 `
g 的 removeChild(childrenShape) 方法 第二个参数原先默认是 false , 就没传。   现在默认为true了， 传入 false.

`第一次点击没反应 & demo 文案需要优化下`
第一次没反应是外部初始化 checked 为true 转化后 还是 false，之后是 true。 已经更改默认
