### PR TITLE
build: use webpack bundling UMD

### DIFF
--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -1,9 +1,8 @@
 export default {
   esm: 'rollup',
   cjs: 'rollup',
-  umd: {
-    minFile: true,
-    file: 'gui',
-    name: 'GUI',
+  umd: false,
+  nodeResolveOpts: {
+    mainFields: ['module', 'browser', 'main'],
   },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ temp
 demos/assets/screenshots
 lib
 es
+esm
 
 *.sw*
 *.un~

--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,7 @@ temp
 .idea
 demos/assets/screenshots
 lib
-esm
+es
 
 *.sw*
 *.un~

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ UI components for [G](https://github.com/antvis/g).
 
 ## ✨ Features
 
-
 ## 📦 Installation
 
 ```bash
@@ -27,12 +26,16 @@ $ npm install @antv/gui
 
 ```ts
 import { Canvas } from '@antv/g';
-import { Arrow } from '@antv/gui';
+import { Button } from '@antv/gui';
 
 // add `arrow` instance into canvas
-const canvas = new Canvas({/* ... */});
-const arrow = new Arrow({/* ... */});
-canvas.appendChild(arrow);
+const canvas = new Canvas({
+  /* ... */
+});
+const button = new Button({
+  /* ... */
+});
+canvas.appendChild(button);
 
 // render it
 canvas.render();

--- a/__tests__/unit/ui/legend/category-item-spec.ts
+++ b/__tests__/unit/ui/legend/category-item-spec.ts
@@ -98,7 +98,6 @@ const categoryItem = new CategoryItem({
 });
 
 canvas.appendChild(categoryItem);
-console.log(categoryItem);
 
 describe('category-item', () => {
   test('default', () => {

--- a/__tests__/unit/ui/switch/index-spec.ts
+++ b/__tests__/unit/ui/switch/index-spec.ts
@@ -238,7 +238,6 @@ describe('switch', () => {
   test('destroy switch', () => {
     switchShape.destroy();
     expect(get(switchShape, ['children'])).toEqual([]);
-    console.log(canvas.document.children);
     // TODO 单测错误，会导致循环输出
     // expect(get(canvas, ['document', 'children'])).toEqual([]);
   });

--- a/__tests__/unit/util/style-spec.ts
+++ b/__tests__/unit/util/style-spec.ts
@@ -49,7 +49,6 @@ describe('getStyle', () => {
       },
     };
     applyStyleSheet(dom, styleSheet);
-    console.log(dom);
 
     expect(dom.style.width).toBe('100px');
     expect(dom.querySelector('.b').style.backgroundColor).toBe('red');

--- a/__tests__/unit/util/text-spec.ts
+++ b/__tests__/unit/util/text-spec.ts
@@ -43,7 +43,7 @@ describe('text', () => {
     const testText = 'test text test text';
     const han = '汉字测试文本';
 
-    expect(getEllipsisText(testText, 20, NEW_FONT_STYLE)).toBe('...');
+    expect(getEllipsisText(testText, 20, NEW_FONT_STYLE)).toBe('t...');
     expect(getEllipsisText(testText, 40, NEW_FONT_STYLE)).toBe('tes...');
     expect(getEllipsisText(testText, 60, NEW_FONT_STYLE)).toBe('test t...');
     expect(getEllipsisText(testText, 120, NEW_FONT_STYLE)).toBe('test text test t...');

--- a/__tests__/unit/util/text-spec.ts
+++ b/__tests__/unit/util/text-spec.ts
@@ -43,7 +43,7 @@ describe('text', () => {
     const testText = 'test text test text';
     const han = '汉字测试文本';
 
-    expect(getEllipsisText(testText, 20, NEW_FONT_STYLE)).toBe('t...');
+    expect(getEllipsisText(testText, 20, NEW_FONT_STYLE)).toBe('...');
     expect(getEllipsisText(testText, 40, NEW_FONT_STYLE)).toBe('tes...');
     expect(getEllipsisText(testText, 60, NEW_FONT_STYLE)).toBe('test t...');
     expect(getEllipsisText(testText, 120, NEW_FONT_STYLE)).toBe('test text test t...');

--- a/index.html
+++ b/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
+  <title>GUI UMD Demo</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      height: 100%;
+    }
+
+    #container {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="container"></div>
+  
+  <script src="https://unpkg.com/@antv/g@next/dist/index.umd.js" type="application/javascript"></script>
+  <script src="https://unpkg.com/@antv/g-canvas@next/dist/index.umd.js" type="application/javascript"></script>
+  <script src="./dist/index.umd.js" type="application/javascript"></script>
+  <script>
+    const { Canvas } = window.G;
+    const { Renderer } = window.G.Canvas2D;
+    const { Button } = window.GUI;
+
+    // create a renderer
+    const canvasRenderer = new Renderer();
+
+    // create a canvas
+    const canvas = new Canvas({
+      container: 'container',
+      width: 600,
+      height: 500,
+      renderer: canvasRenderer,
+    });
+
+    // create a simple button
+    const button = new Button({
+      style: {
+        x: 50,
+        y: 50,
+        text: 'Simple Button',
+      },
+    });
+
+    canvas.appendChild(button);
+  </script>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   
   <script src="https://unpkg.com/@antv/g@next/dist/index.umd.js" type="application/javascript"></script>
   <script src="https://unpkg.com/@antv/g-canvas@next/dist/index.umd.js" type="application/javascript"></script>
-  <script src="./dist/index.umd.js" type="application/javascript"></script>
+  <script src="./dist/gui.min.js" type="application/javascript"></script>
   <script>
     const { Canvas } = window.G;
     const { Renderer } = window.G.Canvas2D;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/gui",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "UI components for AntV G.",
   "license": "MIT",
   "main": "lib/index.js",
@@ -41,7 +41,6 @@
   ],
   "dependencies": {
     "@antv/dom-util": "^2.0.3",
-    "@antv/g": "^1.0.0-alpha.36",
     "@antv/matrix-util": "^3.0.4",
     "@antv/path-util": "^2.0.15",
     "@antv/scale": "^0.4.3",
@@ -50,7 +49,11 @@
     "fecha": "^4.2.1",
     "svg-path-parser": "^1.1.0"
   },
+  "peerDependencies": {
+    "@antv/g": "^1.0.0-alpha.36"
+  },
   "devDependencies": {
+    "@antv/g": "^1.0.0-alpha.36",
     "@antv/g-canvas": "^1.0.0-alpha.37",
     "@antv/g-svg": "^1.0.0-alpha.37",
     "@antv/gatsby-theme-antv": "^1.1.8",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "0.3.1",
   "description": "UI components for AntV G.",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.esm.js",
-  "unpkg": "dist/index.umd.js",
-  "types": "dist/index.d.ts",
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "unpkg": "dist/gui.min.js",
+  "types": "lib/index.d.ts",
   "files": [
     "src",
+    "lib",
+    "esm",
     "dist"
   ],
   "scripts": {
@@ -23,8 +25,10 @@
     "coverage": "jest -w 16 --coverage",
     "test": "jest",
     "test-live": "cross-env DEBUG_MODE=1 jest --watch ./__tests__",
-    "build": "father build && npm run build:umd && limit-size",
+    "build": "run-s clean build:* size",
     "build:umd": "webpack",
+    "build:cjs": "tsc -p tsconfig.json --target ES5 --module commonjs --outDir lib",
+    "build:esm": "tsc -p tsconfig.json --target ES5 --module ESNext --outDir esm",
     "ci": "run-s lint coverage build",
     "prepublishOnly": "npm run ci",
     "prepare": "husky install"
@@ -69,7 +73,6 @@
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
-    "father": "^2.30.9",
     "gatsby": "^2.24.63",
     "husky": "^5.0.9",
     "jest": "^26.6.3",
@@ -120,13 +123,13 @@
   },
   "limit-size": [
     {
-      "path": "dist/index.umd.js",
-      "limit": "256 Kb",
+      "path": "dist/gui.min.js",
+      "limit": "128 Kb",
       "gzip": true
     },
     {
-      "path": "dist/index.umd.js",
-      "limit": "512 Kb"
+      "path": "dist/gui.min.js",
+      "limit": "256 Kb"
     }
   ],
   "author": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,10 @@
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
-  "unpkg": "dist/gui.min.js",
+  "unpkg": "dist/index.umd.js",
   "types": "dist/index.d.ts",
   "files": [
     "src",
-    "lib",
-    "esm",
     "dist"
   ],
   "scripts": {
@@ -25,7 +23,8 @@
     "coverage": "jest -w 16 --coverage",
     "test": "jest",
     "test-live": "cross-env DEBUG_MODE=1 jest --watch ./__tests__",
-    "build": "father-build && limit-size",
+    "build": "father build && npm run build:umd && limit-size",
+    "build:umd": "webpack",
     "ci": "run-s lint coverage build",
     "prepublishOnly": "npm run ci",
     "prepare": "husky install"
@@ -38,9 +37,7 @@
   ],
   "dependencies": {
     "@antv/dom-util": "^2.0.3",
-    "@antv/g": "^1.0.0-alpha.23",
-    "@antv/g-canvas": "^1.0.0-alpha.23",
-    "@antv/g-svg": "^1.0.0-alpha.23",
+    "@antv/g": "^1.0.0-alpha.36",
     "@antv/matrix-util": "^3.0.4",
     "@antv/path-util": "^2.0.15",
     "@antv/scale": "^0.4.3",
@@ -50,7 +47,10 @@
     "svg-path-parser": "^1.1.0"
   },
   "devDependencies": {
+    "@antv/g-canvas": "^1.0.0-alpha.37",
+    "@antv/g-svg": "^1.0.0-alpha.37",
     "@antv/gatsby-theme-antv": "^1.1.8",
+    "@babel/plugin-proposal-class-properties": "^7.3.4",
     "@babel/plugin-proposal-decorators": "^7.15.4",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^12.0.1",
@@ -69,7 +69,7 @@
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
-    "father-build": "^1.19.6",
+    "father": "^2.30.9",
     "gatsby": "^2.24.63",
     "husky": "^5.0.9",
     "jest": "^26.6.3",
@@ -85,7 +85,10 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.1",
     "tslib": "^2.2.0",
-    "typescript": "^4.1.5"
+    "typescript": "^4.3.4",
+    "ts-loader": "^9.2.6",
+    "webpack": "^5.64.4",
+    "webpack-cli": "^4.9.1"
   },
   "jest": {
     "runner": "jest-electron/runner",
@@ -117,12 +120,12 @@
   },
   "limit-size": [
     {
-      "path": "dist/gui.min.js",
+      "path": "dist/index.umd.js",
       "limit": "256 Kb",
       "gzip": true
     },
     {
-      "path": "dist/gui.min.js",
+      "path": "dist/index.umd.js",
       "limit": "512 Kb"
     }
   ],

--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -411,8 +411,6 @@ export class Continuous extends LegendBase<ContinuousCfg> {
       const range = [min, ...ticks!, max];
       for (let i = 0; i < range.length - 1; i += 1) {
         if (value >= range[i] && value <= range[i + 1]) {
-          console.log(minBy([range[i], range[i + 1]], (val) => Math.abs(value - val)));
-
           return minBy([range[i], range[i + 1]], (val) => Math.abs(value - val));
         }
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "skipLibCheck": true,
     "sourceRoot": "src",
     "baseUrl": "src",
-    "strict": true
+    "strict": true,
+    "importHelpers": true,
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "examples"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "baseUrl": "src",
     "strict": true,
     "importHelpers": true,
+    "downlevelIteration": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "examples"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  mode: 'production',
+  entry: './src/index.ts',
+  resolve: {
+    extensions: [".ts", ".tsx", ".js"]
+  },
+  module: {
+    rules: [
+      { test: /\.tsx?$/, loader: "ts-loader" }
+    ]
+  },
+  externals: {
+    '@antv/g': {
+      commonjs: '@antv/g',
+      commonjs2: '@antv/g',
+      amd: '@antv/g',
+      root: 'G',
+    },
+  },
+  output: {
+    library: 'GUI',
+    libraryTarget: 'umd',
+    filename: 'index.umd.js',
+  },
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   mode: 'production',
   entry: './src/index.ts',
+  output: {
+    library: 'GUI',
+    libraryTarget: 'umd',
+    filename: 'gui.min.js',
+  },
   resolve: {
     extensions: [".ts", ".tsx", ".js"]
   },
@@ -16,10 +21,5 @@ module.exports = {
       amd: '@antv/g',
       root: 'G',
     },
-  },
-  output: {
-    library: 'GUI',
-    libraryTarget: 'umd',
-    filename: 'index.umd.js',
   },
 };


### PR DESCRIPTION
使用 Webpack5 构建 UMD，external 掉 `@antv/g`，将 `@antv/g-canvas` 等渲染器包移入开发依赖。

构建命令还是和原来一样：`yarn build`，会生成`dist/index.umd.js`
可以启动本地开发服务器预览：`http-server`

对外暴露 `GUI` 命名空间：
```js
output: {
    library: 'GUI',
    libraryTarget: 'umd',
    filename: 'index.umd.js',
},
```

CDN 用法如下，[G 的 CDN 用法](http://g-next.antv.vision/zh/docs/guide/introduce#cdn-%E6%96%B9%E5%BC%8F)：
```html
<script src="https://unpkg.com/@antv/g@next/dist/index.umd.js" type="application/javascript"></script>
<script src="https://unpkg.com/@antv/g-canvas@next/dist/index.umd.js" type="application/javascript"></script>
<script src="./dist/index.umd.js" type="application/javascript"></script> <!-- gui umd -->
<script>
  const { Canvas } = window.G;
  const { Renderer } = window.G.Canvas2D;
  const { Button } = window.GUI;

  // create a renderer
  const canvasRenderer = new Renderer();

  // create a canvas
  const canvas = new Canvas({
    container: 'container',
    width: 600,
    height: 500,
    renderer: canvasRenderer,
  });

  // create a simple button
  const button = new Button({
    style: {
      x: 50,
      y: 50,
      text: 'Simple Button',
    },
  });

  canvas.appendChild(button);
</script>
```