### PR TITLE
refactor(switch): 改造 switch 组件，添加类型注释 & 移除不需要的配置属性

### DIFF
--- a/__tests__/unit/ui/switch/index-spec.ts
+++ b/__tests__/unit/ui/switch/index-spec.ts
@@ -31,13 +31,12 @@ describe('switch', () => {
   canvas.appendChild(switchShape);
 
   test('basic switch', () => {
-    const { x, y, defaultChecked, spacing, textSpacing } = switchShape.attributes;
+    const { x, y, defaultChecked, spacing } = switchShape.attributes;
 
     expect(x).toBe(40);
     expect(y).toBe(50);
     expect(defaultChecked).toBe(false);
     expect(spacing).toBe(2);
-    expect(textSpacing).toBe(8);
     expect(switchShape.getChecked()).toBe(false);
     expect(get(switchShape, 'backgroundShape.attributes.fill')).toBe('#00000040');
     expect(get(switchShape, 'rectStrokeShape.attributes.stroke')).toBe('#00000040');
@@ -208,21 +207,23 @@ describe('switch', () => {
       height: 18,
       radius: 9,
     });
-    expect(get(childrenSwitchShape, ['childrenShape', '0', 'attributes', 'x'])).toBe(8);
+    expect(get(childrenSwitchShape, ['childrenShape', '0', 'attributes', 'x'])).toBe(7);
 
+    const size = 44;
+    const spacing = 4;
     childrenSwitchShape.update({
       checked: true,
-      spacing: 4,
-      textSpacing: 20,
+      spacing,
+      size,
     });
     expect(get(childrenSwitchShape, 'handleShape.attributes')).toMatchObject({
       x: 4,
       y: 4,
-      width: 14,
-      height: 14,
-      radius: 7,
+      width: size - spacing * 2,
+      height: size - spacing * 2,
+      radius: (size - spacing * 2) / 2,
     });
-    expect(get(childrenSwitchShape, ['childrenShape', '0', 'attributes', 'x'])).toBe(20);
+    expect(get(childrenSwitchShape, ['childrenShape', '0', 'attributes', 'x'])).toBe(Math.floor(size / 3));
 
     expect(get(childrenSwitchShape, ['backgroundShape', 'children', '1', 'config', 'name'])).toBe('checkedChildren');
 

--- a/examples/basic-ui/switch/demo/meta.json
+++ b/examples/basic-ui/switch/demo/meta.json
@@ -13,6 +13,14 @@
       "screenshot": ""
     },
     {
+      "filename": "children-switch.ts",
+      "title": {
+        "zh": "带有文字和图标 开关",
+        "en": "With text and icon switch"
+      },
+      "screenshot": ""
+    },
+    {
       "filename": "size-switch.ts",
       "title": {
         "zh": "控制大小 开关",
@@ -25,14 +33,6 @@
       "title": {
         "zh": "按钮控制 开关",
         "en": "Push button control switch"
-      },
-      "screenshot": ""
-    },
-    {
-      "filename": "children-switch.ts",
-      "title": {
-        "zh": "带有文字和图标 开关",
-        "en": "With text and icon switch"
       },
       "screenshot": ""
     }

--- a/examples/basic-ui/switch/demo/size-switch.ts
+++ b/examples/basic-ui/switch/demo/size-switch.ts
@@ -1,5 +1,5 @@
 import { Canvas } from '@antv/g';
-import { Switch } from '@antv/gui';
+import { Switch, Marker } from '@antv/gui';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 
 const renderer = new CanvasRenderer({
@@ -15,29 +15,79 @@ const canvas = new Canvas({
   renderer,
 });
 
-const bigSwitch = new Switch({
-  style: {
-    x: 50,
-    y: 50,
-    size: 28,
-  },
-});
-
 const defaultSwitch = new Switch({
   style: {
     x: 50,
-    y: 90,
+    y: 50,
   },
 });
 
 const smallSwitch = new Switch({
   style: {
     x: 50,
-    y: 120,
-    size: 14,
+    y: 80,
+    size: 'small',
+  },
+});
+
+const miniSwitch = new Switch({
+  style: {
+    x: 50,
+    y: 100,
+    size: 'mini',
   },
 });
 
 canvas.appendChild(defaultSwitch);
 canvas.appendChild(smallSwitch);
-canvas.appendChild(bigSwitch);
+canvas.appendChild(miniSwitch);
+
+const defaultSwitch2 = new Switch({
+  style: {
+    x: 120,
+    y: 50,
+    checkedChildren: { text: '开启' },
+    unCheckedChildren: { text: '关闭' },
+  },
+});
+
+const smallSwitch2 = new Switch({
+  style: {
+    x: 120,
+    y: 80,
+    size: 'small',
+    checkedChildren: { text: '开启' },
+    unCheckedChildren: { text: '关闭' },
+  },
+});
+
+Marker.registerSymbol('check', (x, y, r) => {
+  return [
+    ['M', x - r / 2, y + r / 8],
+    ['L', x - r / 8, y + r / 2],
+    ['L', x + r / 3, y - r / 2],
+  ];
+});
+
+Marker.registerSymbol('uncheck', (x, y, r) => {
+  return [
+    ['M', x - r / 2, y - r / 2],
+    ['L', x + r / 2, y + r / 2],
+    ['M', x + r / 2, y - r / 2],
+    ['L', x - r / 2, y + r / 2],
+  ];
+});
+
+const miniSwitch2 = new Switch({
+  style: {
+    x: 120,
+    y: 100,
+    size: 'mini',
+    checkedChildren: { marker: { symbol: 'check', stroke: '#fff' } },
+    unCheckedChildren: { marker: { symbol: 'uncheck', stroke: '#fff' } },
+  },
+});
+
+canvas.appendChild(defaultSwitch2);
+canvas.appendChild(smallSwitch2);
+canvas.appendChild(miniSwitch2);

--- a/src/types/compose.ts
+++ b/src/types/compose.ts
@@ -1,0 +1,30 @@
+/**
+ * @file 有原子、或分子组件 组合的分子组件 相关类型定义
+ */
+
+import { TagCfg } from '../ui/tag/types';
+import { TextProps } from './dependency';
+
+/**
+ * 通用的标签属性 （不需要 Tag 组件灵活的交互样式设置）
+ *
+ * @title 标签，带文本、marker。
+ * @description 标签，可以设置文本、marker 以及相关的文本样式和 marker 样式
+ */
+export type LabelProps = {
+  /**
+   * @title 文本内容
+   * @description 展示的标签文本
+   */
+  text?: TagCfg['text'];
+  /**
+   * @title 文本样式
+   * @description 文本样式设置，可以调整文本 fontSize、lineHeight 等，详细见: G5.0 Text 文本额外属性配置
+   */
+  textStyle?: Omit<TextProps, 'text'>;
+  /**
+   * @title 图标
+   * @description 标签文本前缀的图标
+   */
+  marker?: TagCfg['marker'];
+};

--- a/src/types/dependency.ts
+++ b/src/types/dependency.ts
@@ -1,0 +1,15 @@
+export type {
+  BaseStyleProps as ShapeAttrs,
+  DisplayObject,
+  DisplayObjectConfig,
+  CircleStyleProps as CircleProps,
+  EllipseStyleProps as EllipseProps,
+  RectStyleProps as RectProps,
+  ImageStyleProps as ImageProps,
+  LineStyleProps as LineProps,
+  PathStyleProps as PathProps,
+  PolylineStyleProps as PolylineProps,
+  TextStyleProps as TextProps,
+  Group,
+  PathCommand,
+} from '@antv/g';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,18 +1,4 @@
-export type {
-  BaseStyleProps as ShapeAttrs,
-  DisplayObject,
-  DisplayObjectConfig,
-  CircleStyleProps as CircleProps,
-  EllipseStyleProps as EllipseProps,
-  RectStyleProps as RectProps,
-  ImageStyleProps as ImageProps,
-  LineStyleProps as LineProps,
-  PathStyleProps as PathProps,
-  PolylineStyleProps as PolylineProps,
-  TextStyleProps as TextProps,
-  Group,
-  PathCommand,
-} from '@antv/g';
+export * from './dependency';
 export type { MixAttrs, StyleState } from './styles';
 
 export type GUIOption<C> = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './dependency';
+export * from './compose';
 export type { MixAttrs, StyleState } from './styles';
 
 export type GUIOption<C> = {

--- a/src/types/styles.ts
+++ b/src/types/styles.ts
@@ -8,7 +8,7 @@ import type {
   PathProps,
   PolylineProps,
   TextProps,
-} from './index';
+} from './dependency';
 import { STATE_LIST } from '../constant';
 
 type UnionShapeProps =

--- a/src/ui/button/types.ts
+++ b/src/ui/button/types.ts
@@ -5,14 +5,24 @@ import type { DisplayObjectConfig, MixAttrs, TextProps, RectProps } from '../../
 export type IMarkerCfg = Omit<MarkerCfg, 'symbol'>;
 
 export type ButtonCfg = {
+  /**
+   * @title x 坐标
+   * @description 局部坐标系下 x 轴坐标
+   */
   x?: number;
+  /**
+   * @title y 坐标
+   * @description 局部坐标系下 y 轴坐标
+   */
   y?: number;
   /**
-   * 按钮类型
+   * @title 类型
+   * @description 按钮类型
    */
   type?: 'primary' | 'dashed' | 'link' | 'text' | 'default';
   /**
-   * 按钮尺寸
+   * @title 大小
+   * @description 按钮大小尺寸
    */
   size?: 'small' | 'middle' | 'large';
   /**

--- a/src/ui/switch/constant.ts
+++ b/src/ui/switch/constant.ts
@@ -1,0 +1,44 @@
+/**
+ * 尺寸配置
+ */
+export const SIZE_STYLE = {
+  default: {
+    sizeStyle: {
+      width: 44,
+      height: 22,
+    },
+    textStyle: {
+      fontSize: 12,
+      lineHeight: 12,
+    },
+    markerStyle: {
+      size: 11,
+    },
+  },
+  small: {
+    sizeStyle: {
+      width: 28,
+      height: 16,
+    },
+    textStyle: {
+      fontSize: 10,
+      lineHeight: 10,
+    },
+    markerStyle: {
+      size: 8,
+    },
+  },
+  mini: {
+    sizeStyle: {
+      width: 20,
+      height: 14,
+    },
+    textStyle: {
+      fontSize: 7,
+      lineHeight: 7,
+    },
+    markerStyle: {
+      size: 7,
+    },
+  },
+};

--- a/src/ui/switch/index.ts
+++ b/src/ui/switch/index.ts
@@ -74,7 +74,6 @@ export class Switch extends GUI<Required<SwitchCfg>> {
       y: 0,
       size: 22,
       spacing: 2,
-      textSpacing: 8,
       defaultChecked: true,
       style: {
         default: {
@@ -258,7 +257,7 @@ export class Switch extends GUI<Required<SwitchCfg>> {
       }
 
       const childrenShape = this.childrenShape[index];
-      const textSpacing = Number(this.attributes.textSpacing) || (Switch.defaultOptions.style.textSpacing as number);
+      const textSpacing = this.getTextSpacing();
 
       // children 为正常 对象 则更新
       if (isPlainObject(children)) {
@@ -328,6 +327,13 @@ export class Switch extends GUI<Required<SwitchCfg>> {
     });
   }
 
+  /**
+   * 获取文本和边界的距离，默认取: 1/3 高度
+   */
+  private getTextSpacing(): number {
+    return Math.floor(this.sizeStyle.height / 3);
+  }
+
   // 获取背景Shape宽度  在有tag 和 无tag 的情况下是不同的
   private getShapeWidth() {
     const width = Number(get(this.attributes.style, [this.checked ? 'selected' : 'default', 'width']));
@@ -335,7 +341,7 @@ export class Switch extends GUI<Required<SwitchCfg>> {
       return width;
     }
 
-    const textSpacing = Number(this.attributes.textSpacing) || (Switch.defaultOptions.style.textSpacing as number);
+    const textSpacing = this.getTextSpacing();
     const childrenStyle = get(this.attributes, [this.checked ? 'checkedChildren' : 'unCheckedChildren']);
     const childrenShape = this.childrenShape[this.checked ? 0 : 1];
     const childrenWidth = childrenStyle ? getShapeSpace(childrenShape)?.width + textSpacing - this.sizeStyle.height : 0;
@@ -400,11 +406,11 @@ export class Switch extends GUI<Required<SwitchCfg>> {
         this.checked = checked || !this.checked;
         this.animateFlag = isNil(checked);
         this.nowFocus = true;
-        isFunction(onChange) && onChange(this.checked);
+        isFunction(onChange) && onChange(this.checked, e);
         this.updateShape();
         this.animateSiwtch();
       });
-      isFunction(onClick) && onClick(e, this.checked);
+      isFunction(onClick) && onClick(this.checked, e);
     });
   }
 

--- a/src/ui/switch/types.ts
+++ b/src/ui/switch/types.ts
@@ -1,5 +1,5 @@
-import type { TagCfg } from '../tag/types';
 import type { DisplayObjectConfig, MixAttrs, RectProps } from '../../types';
+import type { LabelProps } from '../../types/compose';
 
 export type SwitchCfg = {
   /**
@@ -14,10 +14,10 @@ export type SwitchCfg = {
   y?: number;
   /**
    * @title 大小
-   * @description switch 开关组件大小。组件的高度等于 size，宽度默认等于 size * 2，会随着内部的子元素大小自动调整。
-   * @default 22
+   * @description switch 开关组件大小。默认为: default, 高度大小等于 22px，宽度默认等于高度的两倍，会随着内部的子元素大小自动调整。
+   * @default 'default'
    */
-  size?: number;
+  size?: 'default' | 'small' | 'mini';
   /**
    * @title 是否选中
    * @description 指定当前是否选中
@@ -42,14 +42,14 @@ export type SwitchCfg = {
   defaultChecked?: boolean;
   /**
    * @title 选中时的内容
-   * @description 选中时的内容。可以设置一个 Tag 组件类型，自定义文本和图标
+   * @description 选中时的内容。可以自定义文本和图标
    */
-  checkedChildren?: TagCfg;
+  checkedChildren?: LabelProps;
   /**
    * @title 非选中时的内容
-   * @description 选中时的内容。可以设置一个 Tag 组件类型，自定义文本和图标
+   * @description 选中时的内容。可以自定义文本和图标
    */
-  unCheckedChildren?: TagCfg;
+  unCheckedChildren?: LabelProps;
   /**
    * @title 样式
    * @description 可设置组件的默认样式（default）和选中样式（selected）

--- a/src/ui/switch/types.ts
+++ b/src/ui/switch/types.ts
@@ -2,19 +2,69 @@ import type { TagCfg } from '../tag/types';
 import type { DisplayObjectConfig, MixAttrs, RectProps } from '../../types';
 
 export type SwitchCfg = {
+  /**
+   * @title x 坐标
+   * @description 局部坐标系下 x 轴坐标
+   */
   x?: number;
+  /**
+   * @title y 坐标
+   * @description 局部坐标系下 y 轴坐标
+   */
   y?: number;
+  /**
+   * @title 大小
+   * @description switch 开关组件大小。组件的高度等于 size，宽度默认等于 size * 2，会随着内部的子元素大小自动调整。
+   * @default 22
+   */
   size?: number;
-  style?: MixAttrs<Partial<RectProps>>;
+  /**
+   * @title 是否选中
+   * @description 指定当前是否选中
+   */
   checked?: boolean;
+  /**
+   * @title 是否禁用
+   * @description 指定当前是否禁用
+   */
   disabled?: boolean;
+  /**
+   * @title 组件的内边距
+   * @description 组件的内边距
+   * @default 2
+   */
   spacing?: number;
-  textSpacing?: number;
+  /**
+   * @title 初始是否选中
+   * @description 指定组件的初始状态，是否选中
+   * @default true
+   */
   defaultChecked?: boolean;
+  /**
+   * @title 选中时的内容
+   * @description 选中时的内容。可以设置一个 Tag 组件类型，自定义文本和图标
+   */
   checkedChildren?: TagCfg;
+  /**
+   * @title 非选中时的内容
+   * @description 选中时的内容。可以设置一个 Tag 组件类型，自定义文本和图标
+   */
   unCheckedChildren?: TagCfg;
-  onChange?: (checked: boolean) => void;
-  onClick?: (e: Event, checked: boolean) => void;
+  /**
+   * @title 样式
+   * @description 可设置组件的默认样式（default）和选中样式（selected）
+   */
+  style?: MixAttrs<Partial<RectProps>>;
+  /**
+   * @title 变化时回调函数
+   * @description 变化时回调函数
+   */
+  onChange?: (checked: boolean, e: Event) => void;
+  /**
+   * @title 点击时回调函数
+   * @description 点击时回调函数
+   */
+  onClick?: (checked: boolean, e: Event) => void;
 };
 
 export type SwitchOptions = DisplayObjectConfig<SwitchCfg>;


### PR DESCRIPTION
主要做了以下事情：
1. 类型定义完善注释
2. Switch 组件部分配置完善：
    - `size` 直接封装了 3 种类型：`default`, `small` 以及 `mini` (后续可以贴合设计要求，对尺寸大小进行调整)
    - `checkedChildren`,  `unCheckedChildren` 虽然内部依赖了 `Tag` 组件，但不能直接透出相关配置，应该从 Switch 的角度出发，去精简配置（这里抽取了 `LabelProps`, 使用了需要文本以及 marker，且不存在文本状态样式的情形）
    - `onClick` & `onChange` 事件参数保持一致

TODO: ref #108 