### PR TITLE
feat(toolbox): 工具箱组件

### DIFF
--- a/examples/basic-ui/toolbox/demo/basic.ts
+++ b/examples/basic-ui/toolbox/demo/basic.ts
@@ -1,0 +1,27 @@
+import { Canvas } from '@antv/g';
+import { Renderer as CanvasRenderer } from '@antv/g-canvas';
+import { Toolbox } from '@antv/gui';
+
+const renderer = new CanvasRenderer({
+  enableDirtyRectangleRenderingDebug: false,
+  enableAutoRendering: true,
+  enableDirtyRectangleRendering: true,
+});
+
+const canvas = new Canvas({
+  container: 'container',
+  width: 300,
+  height: 300,
+  renderer,
+});
+
+const toolbox = new Toolbox({
+  style: {
+    features: ['reset', 'reload', 'download'],
+    onClick: (name) => {
+      console.info('name:', name);
+    },
+  },
+});
+
+canvas.appendChild(toolbox);

--- a/examples/basic-ui/toolbox/demo/meta.json
+++ b/examples/basic-ui/toolbox/demo/meta.json
@@ -1,0 +1,16 @@
+{
+  "title": {
+    "zh": "中文分类",
+    "en": "Category"
+  },
+  "demos": [
+    {
+      "filename": "basic.ts",
+      "title": {
+        "zh": "Toolbox",
+        "en": "Toolbox"
+      },
+      "screenshot": ""
+    }
+  ]
+}

--- a/examples/basic-ui/toolbox/index.en.md
+++ b/examples/basic-ui/toolbox/index.en.md
@@ -1,0 +1,4 @@
+---
+title: Toolbox
+order: 2
+---

--- a/examples/basic-ui/toolbox/index.zh.md
+++ b/examples/basic-ui/toolbox/index.zh.md
@@ -1,0 +1,4 @@
+---
+title: Toolbox
+order: 2
+---

--- a/src/core/gui.ts
+++ b/src/core/gui.ts
@@ -1,6 +1,6 @@
 import { CustomElement } from '@antv/g';
 
-export abstract class GUI<CustomAttr> extends CustomElement<CustomAttr> {
+export abstract class GUI<CustomElementStyleProps> extends CustomElement<CustomElementStyleProps> {
   public static tag: string = 'gui';
 
   connectedCallback(): void {}
@@ -13,9 +13,20 @@ export abstract class GUI<CustomAttr> extends CustomElement<CustomAttr> {
   public abstract init(): void;
 
   /**
+   * 属性发生修改时触发
+   */
+  attributeChangedCallback?<Key extends keyof CustomElementStyleProps>(
+    name: Key,
+    oldValue: CustomElementStyleProps[Key],
+    newValue: CustomElementStyleProps[Key]
+  ): void;
+
+  // 下面的部分是 GUI 自定义的
+
+  /**
    * 组件的更新
    */
-  public abstract update(cfg: Partial<CustomAttr>): void;
+  public abstract update(cfg: Partial<CustomElementStyleProps>): void;
 
   /**
    * 组件的清除

--- a/src/ui/axis/base.ts
+++ b/src/ui/axis/base.ts
@@ -3,7 +3,7 @@ import { clone, deepMix, minBy, maxBy, get, sortBy, isString, isNumber, isUndefi
 import { vec2 } from '@antv/matrix-util';
 import type { vec2 as Vector } from '@antv/matrix-util';
 import type { PathCommand } from '@antv/g';
-import type { MarkerCfg } from '../marker';
+import type { MarkerStyleProps } from '../marker';
 import type {
   Point,
   TickDatum,
@@ -42,10 +42,10 @@ import { isLabelsOverlap } from './overlap/is-overlap';
 interface IAxisLineCfg {
   style: ShapeAttrs;
   arrow: {
-    start: MarkerCfg & {
+    start: MarkerStyleProps & {
       rotate: number;
     };
-    end: MarkerCfg & {
+    end: MarkerStyleProps & {
       rotate: number;
     };
   };

--- a/src/ui/axis/types.ts
+++ b/src/ui/axis/types.ts
@@ -1,4 +1,4 @@
-import type { MarkerCfg } from '../marker';
+import type { MarkerStyleProps } from '../marker';
 import type { MixAttrs, DisplayObjectConfig, LineProps, ShapeAttrs, StyleState as State, TextProps } from '../../types';
 
 export type LabelType = 'text' | 'number' | 'time';
@@ -27,8 +27,8 @@ export type AxisTitleCfg = {
 export type AxisLineCfg = {
   style?: ShapeAttrs;
   arrow?: {
-    start?: false | MarkerCfg;
-    end?: false | MarkerCfg;
+    start?: false | MarkerStyleProps;
+    end?: false | MarkerStyleProps;
   };
 };
 

--- a/src/ui/button/types.ts
+++ b/src/ui/button/types.ts
@@ -1,8 +1,8 @@
 import { Cursor } from '@antv/g';
-import type { MarkerCfg } from '../marker';
+import type { MarkerStyleProps } from '../marker';
 import type { DisplayObjectConfig, MixAttrs, TextProps, RectProps } from '../../types';
 
-export type IMarkerCfg = Omit<MarkerCfg, 'symbol'>;
+export type IMarkerCfg = Omit<MarkerStyleProps, 'symbol'>;
 
 /**
  * @title Button 组件
@@ -68,7 +68,7 @@ export type ButtonCfg = {
    * @title 图标
    * @description 图标
    */
-  marker?: MarkerCfg['symbol'];
+  marker?: MarkerStyleProps['symbol'];
   /**
    * @description marker 位置
    */

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -63,7 +63,7 @@ export { Text } from './text';
 export type { TextCfg, TextOptions } from './text';
 export { Checkbox } from './checkbox';
 export type { CheckboxOptions } from './checkbox';
-export { Poptip, getPositionXY } from './poptip';
+export { Poptip } from './poptip';
 export type { PoptipCfg, PoptipOptions } from './poptip/types';
 // author by [visiky](https://github.com/visiky)
 export { Toolbox } from './toolbox';

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -64,5 +64,8 @@ export type { TextCfg, TextOptions } from './text';
 export { Checkbox } from './checkbox';
 export type { CheckboxOptions } from './checkbox';
 export { Poptip, getPositionXY } from './poptip';
-export type { PoptipCfg, PoptipOptions } from './poptip';
+export type { PoptipCfg, PoptipOptions } from './poptip/types';
+// author by [visiky](https://github.com/visiky)
+export { Toolbox } from './toolbox';
+export type { ToolboxCfg, ToolboxOptions } from './toolbox/types';
 // to be continued...

--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -11,7 +11,7 @@ import { toPrecision, getShapeSpace, getEventPos, deepAssign } from '../../util'
 import type { Pair } from '../slider/types';
 import type { IRailCfg } from './rail';
 import type { ILabelsCfg } from './labels';
-import type { MarkerCfg } from '../marker';
+import type { MarkerStyleProps } from '../marker';
 import type { DisplayObject, TextProps } from '../../types';
 import type { ContinuousCfg, ContinuousOptions, IndicatorCfg, RailCfg, HandleCfg, SymbolCfg } from './types';
 
@@ -19,7 +19,7 @@ export type { ContinuousOptions };
 
 type HandleType = 'start' | 'end';
 interface IHandleCfg {
-  markerCfg: MarkerCfg;
+  markerCfg: MarkerStyleProps;
   textCfg: TextProps;
 }
 
@@ -520,7 +520,7 @@ export class Continuous extends LegendBase<ContinuousCfg> {
 
     const icon = new Marker({
       name: 'icon',
-      style: markerCfg as MarkerCfg,
+      style: markerCfg as MarkerStyleProps,
     });
     el.appendChild(icon);
 
@@ -581,7 +581,7 @@ export class Continuous extends LegendBase<ContinuousCfg> {
     // 指示器小箭头
     const icon = new Marker({
       name: `arrow`,
-      style: markerCfg as MarkerCfg,
+      style: markerCfg as MarkerStyleProps,
     });
     icon.toBack();
     el.appendChild(icon);

--- a/src/ui/legend/types.ts
+++ b/src/ui/legend/types.ts
@@ -7,11 +7,11 @@ import type {
   ImageProps,
   PathProps,
 } from '../../types';
-import type { MarkerCfg } from '../marker/types';
+import type { MarkerStyleProps } from '../marker/types';
 import type { PageNavigatorCfg } from '../page-navigator';
 
 export type State = StyleState | 'default-active' | 'selected-active';
-export type SymbolCfg = MarkerCfg['symbol'];
+export type SymbolCfg = MarkerStyleProps['symbol'];
 // 色板
 export type RailCfg = {
   // 色板宽度
@@ -66,7 +66,7 @@ type CategoryItem = {
 };
 
 // 图例项图标
-export type ItemMarkerCfg = {
+export type ItemMarkerStyleProps = {
   marker?: SymbolCfg;
   size?: number;
   spacing?: number;
@@ -95,7 +95,7 @@ export type CategoryItemCfg = {
   itemWidth?: number;
   maxItemWidth?: number;
   state?: State;
-  itemMarker: ItemMarkerCfg;
+  itemMarker: ItemMarkerStyleProps;
   itemName: {
     content?: string;
     spacing?: number;
@@ -180,7 +180,9 @@ export type CategoryCfg = LegendBaseCfg & {
   maxItemWidth?: number;
   // 图例项间的间隔
   spacing?: [number, number];
-  itemMarker?: Partial<ItemMarkerCfg> | ((item: CategoryItem, index: number, items: CategoryItem[]) => ItemMarkerCfg);
+  itemMarker?:
+    | Partial<ItemMarkerStyleProps>
+    | ((item: CategoryItem, index: number, items: CategoryItem[]) => ItemMarkerStyleProps);
   itemName?: ItemNameCfg | ((item: CategoryItem, index: number, items: CategoryItem[]) => ItemNameCfg);
   itemValue?: ItemValueCfg | ((item: CategoryItem, index: number, items: CategoryItem[]) => ItemValueCfg);
   itemBackgroundStyle?:

--- a/src/ui/link/index.ts
+++ b/src/ui/link/index.ts
@@ -1,12 +1,12 @@
 import type { Line, Polyline, BaseStyleProps, DisplayObjectConfig, Point } from '@antv/g';
 import { Path } from '@antv/g';
-import { Marker, MarkerCfg } from 'ui/marker';
+import { Marker, MarkerStyleProps } from 'ui/marker';
 import { GUI } from '../../core/gui';
 
 type ArrowBody = Line | Path | Polyline;
 export interface LinkStyleProps extends BaseStyleProps {
-  sourceMarker?: MarkerCfg;
-  targetMarker?: MarkerCfg;
+  sourceMarker?: MarkerStyleProps;
+  targetMarker?: MarkerStyleProps;
   body: ArrowBody;
 }
 
@@ -88,7 +88,7 @@ export class Link extends GUI<LinkStyleProps> {
   // }
   // }
 
-  private appendMarker(style: MarkerCfg, type: 'source' | 'target') {
+  private appendMarker(style: MarkerStyleProps, type: 'source' | 'target') {
     const marker = new Marker({ style });
 
     // set position & rotation

--- a/src/ui/marker/index.ts
+++ b/src/ui/marker/index.ts
@@ -1,23 +1,22 @@
 import { Path, Image, PathCommand, ImageStyleProps, PathStyleProps, DisplayObject } from '@antv/g';
 import { deepMix, isFunction } from '@antv/util';
 import { GUI } from '../../core/gui';
-import type { ShapeAttrs } from '../../types';
 import { parseMarker } from './utils';
 import { circle, square, diamond, triangleDown, triangle, line, dot, dash, smooth, hv, vh, hvh, vhv } from './symbol';
-import type { MarkerCfg, MarkerOptions, FunctionalSymbol } from './types';
+import type { MarkerStyleProps, MarkerOptions, FunctionalSymbol } from './types';
 
-export type { MarkerCfg, MarkerOptions, FunctionalSymbol };
+export type { MarkerStyleProps, MarkerOptions, FunctionalSymbol };
 
 /**
  * Marker
  */
-export class Marker extends GUI<Required<MarkerCfg>> {
+export class Marker extends GUI<Required<MarkerStyleProps>> {
   /**
    * 标签类型
    */
   public static tag = 'marker';
 
-  private markerShape?: DisplayObject;
+  private markerShape?: Path | Image;
 
   private static MARKER_SYMBOL_MAP = new Map<string, FunctionalSymbol>();
 
@@ -51,13 +50,13 @@ export class Marker extends GUI<Required<MarkerCfg>> {
    * 根据 type 获取 maker shape
    */
   public init(): void {
-    this.createMarker();
+    this.update();
   }
 
   /**
    * 组件的更新
    */
-  public update(cfg: Partial<MarkerCfg>): void {
+  public update(cfg?: Partial<MarkerStyleProps>): void {
     this.attr(deepMix({}, this.attributes, cfg));
     this.clear();
     this.createMarker();
@@ -69,15 +68,6 @@ export class Marker extends GUI<Required<MarkerCfg>> {
   public clear() {
     this.markerShape?.destroy();
     this.removeChildren();
-  }
-
-  /**
-   * @override
-   */
-  setAttribute<O extends MarkerCfg, Key extends keyof O>(attributeName: Key, value: O[Key], force?: boolean) {
-    if (this.markerShape) {
-      this.markerShape.setAttribute(attributeName, value, force);
-    }
   }
 
   private createMarker() {

--- a/src/ui/marker/index.ts
+++ b/src/ui/marker/index.ts
@@ -1,6 +1,7 @@
-import { Path, Image, PathCommand, ImageStyleProps, PathStyleProps } from '@antv/g';
+import { Path, Image, PathCommand, ImageStyleProps, PathStyleProps, DisplayObject } from '@antv/g';
 import { deepMix, isFunction } from '@antv/util';
 import { GUI } from '../../core/gui';
+import type { ShapeAttrs } from '../../types';
 import { parseMarker } from './utils';
 import { circle, square, diamond, triangleDown, triangle, line, dot, dash, smooth, hv, vh, hvh, vhv } from './symbol';
 import type { MarkerCfg, MarkerOptions, FunctionalSymbol } from './types';
@@ -16,7 +17,7 @@ export class Marker extends GUI<Required<MarkerCfg>> {
    */
   public static tag = 'marker';
 
-  private markerShape?: Path | Image;
+  private markerShape?: DisplayObject;
 
   private static MARKER_SYMBOL_MAP = new Map<string, FunctionalSymbol>();
 
@@ -68,6 +69,15 @@ export class Marker extends GUI<Required<MarkerCfg>> {
   public clear() {
     this.markerShape?.destroy();
     this.removeChildren();
+  }
+
+  /**
+   * @override
+   */
+  setAttribute<O extends MarkerCfg, Key extends keyof O>(attributeName: Key, value: O[Key], force?: boolean) {
+    if (this.markerShape) {
+      this.markerShape.setAttribute(attributeName, value, force);
+    }
   }
 
   private createMarker() {

--- a/src/ui/marker/types.ts
+++ b/src/ui/marker/types.ts
@@ -2,7 +2,7 @@ import { ShapeAttrs, DisplayObjectConfig } from '../../types';
 
 export type FunctionalSymbol = (x: number, y: number, r: number) => any;
 
-export interface MarkerCfg extends ShapeAttrs {
+export interface MarkerStyleProps extends ShapeAttrs {
   /**
    * 标记的位置 x，默认为 0
    */
@@ -21,4 +21,4 @@ export interface MarkerCfg extends ShapeAttrs {
   symbol: string | FunctionalSymbol;
 }
 
-export type MarkerOptions = DisplayObjectConfig<MarkerCfg>;
+export type MarkerOptions = DisplayObjectConfig<MarkerStyleProps>;

--- a/src/ui/marker/utils.ts
+++ b/src/ui/marker/utils.ts
@@ -1,9 +1,9 @@
 import { isObject, isString, isFunction } from '@antv/util';
-import type { MarkerCfg } from './types';
+import type { MarkerStyleProps } from './types';
 /**
  * 解析marker类型
  */
-export function parseMarker(icon: MarkerCfg['symbol'] | string) {
+export function parseMarker(icon: MarkerStyleProps['symbol'] | string) {
   let type = 'default';
   if (isObject(icon) && icon instanceof Image) type = 'image';
   else if (isFunction(icon)) type = 'symbol';

--- a/src/ui/slider/index.ts
+++ b/src/ui/slider/index.ts
@@ -5,7 +5,7 @@ import { GUI } from '../../core/gui';
 import { Handle } from './handle';
 import { Sparkline } from '../sparkline';
 import { toPrecision, getShapeSpace, getEventPos, getStateStyle, normalPadding } from '../../util';
-import type { MarkerCfg } from '../marker';
+import type { MarkerStyleProps } from '../marker';
 import type { SparklineCfg } from '../sparkline';
 import type { IHandleCfg } from './handle';
 import type { ShapeAttrs, RectProps } from '../../types';
@@ -437,7 +437,7 @@ export class Slider extends GUI<SliderCfg> {
     const { show, handleIcon, handleStyle: style } = handleCfg;
     const cursor = this.getOrientVal(['ew-resize', 'ns-resize']) as Cursor;
     const size = this.getHandleSize(handleType);
-    let tempStyle!: RectProps | MarkerCfg | ShapeAttrs;
+    let tempStyle!: RectProps | MarkerStyleProps | ShapeAttrs;
     let type!: 'hide' | 'default' | 'symbol';
     if (!show) {
       type = 'hide';
@@ -465,7 +465,7 @@ export class Slider extends GUI<SliderCfg> {
         cursor,
         size,
         symbol: handleIcon,
-      } as MarkerCfg;
+      } as MarkerStyleProps;
     }
 
     return {

--- a/src/ui/slider/types.ts
+++ b/src/ui/slider/types.ts
@@ -7,7 +7,7 @@ import type {
   ImageProps,
   PathProps,
 } from '../../types';
-import type { MarkerCfg } from '../marker';
+import type { MarkerStyleProps } from '../marker';
 import type { SparklineCfg } from '../sparkline/types';
 
 export type Pair<T> = [T, T];
@@ -36,7 +36,7 @@ export type HandleCfg = {
   /**
    * 手柄图标
    */
-  handleIcon?: MarkerCfg['symbol'] | string;
+  handleIcon?: MarkerStyleProps['symbol'] | string;
   /**
    * 手柄图标样式
    */

--- a/src/ui/statistic/types.ts
+++ b/src/ui/statistic/types.ts
@@ -1,4 +1,4 @@
-import { MarkerCfg } from 'ui/marker';
+import { MarkerStyleProps } from 'ui/marker';
 import type { DisplayObjectConfig, LabelProps, RectProps } from '../../types';
 
 export type StatisticCfg = {
@@ -21,7 +21,7 @@ export type StatisticCfg = {
      * @title 图标
      * @description 标签文本前缀的图标
      */
-    marker?: MarkerCfg;
+    marker?: MarkerStyleProps;
   };
   /**
    * @title 值 string | 数值 | 时间(毫秒)
@@ -32,7 +32,7 @@ export type StatisticCfg = {
      * @title 图标
      * @description 标签文本前缀的图标
      */
-    marker?: MarkerCfg;
+    marker?: MarkerStyleProps;
   };
   /**
    * @title 间距

--- a/src/ui/switch/types.ts
+++ b/src/ui/switch/types.ts
@@ -1,5 +1,5 @@
 import type { DisplayObjectConfig, MixAttrs, RectProps, LabelProps } from '../../types';
-import type { MarkerCfg } from '../marker/types';
+import type { MarkerStyleProps } from '../marker/types';
 
 export type SwitchCfg = {
   /**
@@ -49,7 +49,7 @@ export type SwitchCfg = {
      * @title 图标
      * @description 标签文本前缀的图标
      */
-    marker?: MarkerCfg;
+    marker?: MarkerStyleProps;
   };
   /**
    * @title 非选中时的内容
@@ -60,7 +60,7 @@ export type SwitchCfg = {
      * @title 图标
      * @description 标签文本前缀的图标
      */
-    marker?: MarkerCfg;
+    marker?: MarkerStyleProps;
   };
   /**
    * @title 样式

--- a/src/ui/tag/index.ts
+++ b/src/ui/tag/index.ts
@@ -2,7 +2,7 @@ import { Rect, RectStyleProps, Text, TextStyleProps } from '@antv/g';
 import { deepMix } from '@antv/util';
 import { GUI } from '../../core/gui';
 import { getStateStyle as getStyle, normalPadding, getShapeSpace } from '../../util';
-import { Marker, MarkerCfg } from '../marker';
+import { Marker, MarkerStyleProps } from '../marker';
 import type { TagCfg, TagOptions } from './types';
 
 export type { TagCfg, TagOptions };
@@ -24,7 +24,7 @@ export class Tag extends GUI<Required<TagCfg>> {
     };
   }
 
-  private get markerShapeCfg(): MarkerCfg {
+  private get markerShapeCfg(): MarkerStyleProps {
     const { marker } = this.attributes;
     return marker;
   }

--- a/src/ui/tag/types.ts
+++ b/src/ui/tag/types.ts
@@ -1,4 +1,4 @@
-import type { MarkerCfg } from '../marker';
+import type { MarkerStyleProps } from '../marker';
 import type { RectProps, TextProps, MixAttrs, DisplayObjectConfig } from '../../types';
 
 export type TagCfg = {
@@ -9,7 +9,7 @@ export type TagCfg = {
   /** tag 文本 */
   text?: string;
   /** 图标类型，也可以自定义; 默认不显示 */
-  marker?: MarkerCfg;
+  marker?: MarkerStyleProps;
   /** text 和 marker 的间距，默认为 4px (只有当 marker 存在时，才生效) */
   spacing?: number;
   /** 水平对齐方式 */

--- a/src/ui/toolbox/index.ts
+++ b/src/ui/toolbox/index.ts
@@ -1,0 +1,159 @@
+import { DisplayObject, Group, Rect, Text } from '@antv/g';
+import { GUIOption } from 'types';
+import { deepAssign } from '../../util';
+import { GUI } from '../../core/gui';
+import { FeatureCtor, ToolboxCfg, ToolboxOptions } from './types';
+import { download, reset, reload } from './items';
+
+const FEETURE_CLS = 'feature-item';
+class Toolbox extends GUI<ToolboxCfg> {
+  /**
+   * 组件类型
+   */
+  public static tag = 'toolbox';
+
+  /**
+   * 默认参数
+   */
+  private static defaultOptions: GUIOption<ToolboxCfg> = {
+    type: Toolbox.tag,
+    style: {
+      spacing: 8,
+      features: [],
+      textStyle: {
+        fill: 'rgba(0,0,0,0.65)',
+        textBaseline: 'top',
+        textAlign: 'center',
+      },
+      markerSize: 24,
+      markerStyle: {
+        default: {
+          stroke: '#666',
+        },
+        active: {
+          stroke: '#3471F9',
+        },
+      },
+    },
+  };
+
+  protected static features: Map<string, FeatureCtor> = new Map();
+
+  /**
+   * 当前激活的 feature
+   */
+  private activeFeatures: Set<string> = new Set();
+
+  /**
+   * 注册菜单项
+   */
+  public static registerFeatures(name: string, f: FeatureCtor): void {
+    Toolbox.features.set(name, f);
+  }
+
+  constructor(options: ToolboxOptions) {
+    super(deepAssign({}, Toolbox.defaultOptions, options));
+    this.init();
+    this.layout();
+  }
+
+  /**
+   * 组件的初始化。添加 Toolbox 的各种操作菜单项
+   */
+  public init(): void {
+    // 获取用户传入的自定义属性
+    const { x = 0, y = 0, width, height, features, markerStyle, textStyle = {}, markerSize = 24 } = this.attributes;
+    let clipPath = null;
+    if (width || height) {
+      clipPath = new Rect({
+        style: { x, y, width: width ?? Number.MAX_SAFE_INTEGER, height: height ?? Number.MAX_SAFE_INTEGER },
+      });
+    }
+    const container = new Group({ id: 'container', style: { x, y, clipPath } });
+    features.forEach((feature) => {
+      const markerCtor = Toolbox.features.get(feature);
+      if (markerCtor) {
+        const marker = markerCtor({ size: markerSize });
+        marker.className = FEETURE_CLS;
+        const itemContainer = new Rect({ style: { x: 0, y: 0, width: markerSize, height: markerSize } });
+        const text = new Text({ style: { x: 0, y: 0, text: feature, ...textStyle, fillOpacity: 0 } });
+        // itemContainer 包含 actionItem + text
+        itemContainer.appendChild(marker);
+        itemContainer.appendChild(text);
+        // 设置样式
+        Object.entries(markerStyle?.default || {}).forEach(([key, value]) => marker.setAttribute(key, value));
+        this.bindEvent(itemContainer, text, feature);
+        // 放到 container 中
+        container.appendChild(itemContainer);
+      }
+    });
+    this.appendChild(container);
+  }
+
+  /**
+   * 对元素进行布局
+   */
+  protected layout() {
+    const { spacing = 0 } = this.attributes;
+
+    const container = this.getElementById('container') as Group;
+    const features = container.children as Rect[];
+    features.reduce((dx, feature) => {
+      const bbox = feature.getBoundingClientRect();
+      feature.setLocalPosition(dx, 0);
+      (feature.getElementsByTagName('text')[0] as Text).translateLocal(bbox.width / 2, bbox.height);
+      return dx + bbox.width + spacing;
+    }, 0);
+  }
+
+  public update() {
+    // todo
+  }
+
+  public clear() {}
+
+  /**
+   * 绑定事件
+   */
+  private bindEvent(item: DisplayObject, textShape: DisplayObject, name: string) {
+    const { markerStyle, textStyle, onClick } = this.attributes;
+    const feature = item.firstChild as DisplayObject;
+    if (!feature) return;
+
+    item.addEventListener('mouseenter', () => {
+      item.setAttribute('cursor', 'pointer');
+      textShape.setAttribute('fillOpacity', textStyle?.fillOpacity ?? 1);
+    });
+    item.addEventListener('mouseleave', () => {
+      item.setAttribute('cursor', 'default');
+      textShape.setAttribute('fillOpacity', 0);
+    });
+
+    if (typeof onClick !== 'function') return;
+    item.addEventListener('click', (e) => {
+      // 设置样式
+      const { activeFeatures } = this;
+      const defaultStyles = markerStyle?.default || {};
+      const activeStyles = markerStyle?.active || {};
+
+      if (!activeFeatures.has(feature.name)) {
+        Object.entries(activeStyles).forEach(([key, value]) => feature.setAttribute(key, value));
+        activeFeatures.add(feature.name);
+      } else {
+        Object.entries(defaultStyles).forEach(([key, value]) => feature.setAttribute(key, value));
+        activeFeatures.delete(feature.name);
+      }
+
+      onClick.call(this, name, e);
+    });
+  }
+}
+
+/**
+ * 注册 Toolbox 组件需要的 features 才当
+ */
+Toolbox.registerFeatures('reset', reset);
+Toolbox.registerFeatures('reload', reload);
+Toolbox.registerFeatures('download', download);
+
+export { Toolbox };

--- a/src/ui/toolbox/items/download.ts
+++ b/src/ui/toolbox/items/download.ts
@@ -1,0 +1,35 @@
+import { DisplayObject, Path, Rect } from '@antv/g';
+
+export const download = ({ size = 24, stroke = '#363636' }): DisplayObject => {
+  const rect = new Rect({ style: { x: 0, y: 0, width: size, height: size } });
+  const c = 8.5;
+  const path = new Path({
+    style: {
+      x: 0,
+      y: 0,
+      lineWidth: 1,
+      stroke,
+      path: [
+        ['M', 11.5, 2],
+        ['L', 11.5, 17],
+        ['M', 11.5 - c, 9],
+        ['L', 11.5, 17],
+        ['L', 11.5 + c, 9],
+        ['M', 11.5 - c, 17],
+        ['L', 11.5 - c, 20.5],
+        ['L', 11.5 + c, 20.5],
+        ['L', 11.5 + c, 17],
+      ],
+    },
+  });
+  // path 按照 24px 的进行绘制，然后进行缩放
+  path.setAttribute('origin', [0.5, 0.5]);
+  path.scale(size / 24);
+
+  rect.appendChild(path);
+
+  // @ts-ignore 复写掉（todo 用其他方式注入修改）
+  rect.setAttribute = (k, v) => path.setAttribute(k, v);
+
+  return rect;
+};

--- a/src/ui/toolbox/items/index.ts
+++ b/src/ui/toolbox/items/index.ts
@@ -1,0 +1,3 @@
+export { download } from './download';
+export { reset } from './reset';
+export { reload } from './reload';

--- a/src/ui/toolbox/items/reload.ts
+++ b/src/ui/toolbox/items/reload.ts
@@ -1,0 +1,33 @@
+import { DisplayObject, Path, Rect } from '@antv/g';
+
+export const reload = ({ size = 24, stroke = '#363636' }): DisplayObject => {
+  const rect = new Rect({ style: { x: 0, y: 0, width: size, height: size } });
+  const r = 8;
+  const path = new Path({
+    style: {
+      x: 0,
+      y: 0,
+      lineWidth: 1,
+      stroke,
+      path: [
+        ['M', 3, 10.5],
+        ['A', r, r - 1, 0, 0, 1, 21, 9.5],
+        ['M', 22, 7],
+        ['L', 21, 9.5],
+        ['L', 19, 8],
+        ['M', 4, 13.5],
+        ['A', r, r - 1, 0, 0, 0, 21, 13.5],
+        ['M', 2.5, 15],
+        ['L', 4, 13.5],
+        ['L', 5.5, 15.5],
+      ],
+    },
+  });
+  // path 按照 24px 的进行绘制，然后进行缩放
+  path.setAttribute('origin', [0.5, 0.5]);
+  path.scale(size / 24);
+
+  rect.appendChild(path);
+
+  return rect;
+};

--- a/src/ui/toolbox/items/reset.ts
+++ b/src/ui/toolbox/items/reset.ts
@@ -1,0 +1,31 @@
+import { DisplayObject, Path, Rect } from '@antv/g';
+
+export const reset = ({ size = 24, stroke = '#363636' }): DisplayObject => {
+  const rect = new Rect({ style: { x: 0, y: 0, width: size, height: size } });
+  const c = Math.sqrt(9);
+  const path = new Path({
+    style: {
+      x: 0,
+      y: 0,
+      lineWidth: 1,
+      stroke,
+      path: [
+        ['M', 3, 3],
+        ['L', 21, 3],
+        ['L', 21, 21],
+        ['L', 3, 21],
+        ['L', 3, 12],
+        ['M', 3 + c, 3 - c],
+        ['L', 3, 3],
+        ['L', 3 + c, 3 + c],
+      ],
+    },
+  });
+  // path 按照 24px 的进行绘制，然后进行缩放
+  path.setAttribute('origin', [0.5, 0.5]);
+  path.scale(size / 24);
+
+  rect.appendChild(path);
+
+  return rect;
+};

--- a/src/ui/toolbox/types.ts
+++ b/src/ui/toolbox/types.ts
@@ -1,0 +1,67 @@
+import type { DisplayObject, DisplayObjectConfig, MixAttrs, ShapeAttrs, TextProps } from '../../types';
+
+/**
+ * @title toolbox 菜单项的构造函数
+ */
+export type FeatureCtor = (style: { size?: number }) => DisplayObject;
+
+/**
+ * @title Toolbox 组件
+ */
+export type ToolboxCfg = {
+  /**
+   * @title x 坐标
+   * @description 局部坐标系下 x 轴坐标
+   * @default 0
+   */
+  x?: number;
+  /**
+   * @title y 坐标
+   * @description 局部坐标系下 y 轴坐标
+   * @default 0
+   */
+  y?: number;
+  /**
+   * @title 宽度
+   * @title toolbox 容器宽度，默认根据子元素自适应
+   */
+  width?: number;
+  /**
+   * @title 高度
+   * @title toolbox 容器高度，默认根据子元素自适应
+   */
+  height?: number;
+  /**
+   * @title 菜单项列表
+   */
+  features: string[];
+  /**
+   * @description feature 之间的间距
+   * @default 8
+   */
+  spacing?: number;
+  /**
+   * @description 操作菜单的 marker 大小
+   * @default 24
+   */
+  markerSize?: number;
+  /**
+   * @description 操作菜单的 marker 样式
+   */
+  markerStyle?: MixAttrs<Partial<ShapeAttrs>>;
+  /**
+   * @title 字体样式
+   */
+  textStyle?: Partial<TextProps>;
+  /**
+   * @title 布局
+   * @description 排列布局，纵向或横向
+   */
+  orient?: 'horizontal' | 'vertical';
+  /**
+   * @title 监听点击事件
+   */
+  onClick?: (name: string, e: any) => void;
+};
+
+export type ToolboxOptions = DisplayObjectConfig<ToolboxCfg>;


### PR DESCRIPTION
**实现**

1. 先确定 ui 结构
2. 进行布局

<img width="542" alt="image" src="https://user-images.githubusercontent.com/15646325/155508856-95cccf55-c72a-41fe-b460-9277aa9694ca.png">

- 菜单项，可以通过 `Toolbox.registerFeatures` 注册
- 事件，目前只暴露 onClick 事件，回调有注册的菜单项相应的唯一 key 值


**参考**
<img width="347" alt="image" src="https://user-images.githubusercontent.com/15646325/155507872-042dae7c-5b06-47ac-b127-f079ab5188a6.png">

**实现效果**
<img width="163" alt="image" src="https://user-images.githubusercontent.com/15646325/155507974-f299459a-b3c3-4f5b-832d-9da5a04da2d2.png">

hover：
<img width="141" alt="image" src="https://user-images.githubusercontent.com/15646325/155508037-31ce6834-9f81-4d9f-8a4a-050b629e551c.png">

激活：
<img width="143" alt="image" src="https://user-images.githubusercontent.com/15646325/155508002-ce13b85a-597f-4d19-a248-a32af7889851.png">
