### PR TITLE
fix: poptip width height undefined error

### DIFF
--- a/src/ui/poptip/index.ts
+++ b/src/ui/poptip/index.ts
@@ -19,6 +19,8 @@ export class Poptip extends GUI<Required<PoptipCfg>> {
     style: {
       x: 0,
       y: 0,
+      width: 0,
+      height: 0,
       target: null,
       visibility: 'hidden',
       text: '',


### PR DESCRIPTION
发现new Poptip({}) 会导致width height undefined error，添加了默认宽高