### PR TITLE
fix: 解决 Text 继承问题

### DIFF
--- a/__tests__/unit/ui/axis/arc-spec.ts
+++ b/__tests__/unit/ui/axis/arc-spec.ts
@@ -5,11 +5,7 @@ import { createDiv } from '../../../utils';
 import type { StyleState as State } from '../../../../src/types';
 import type { TickDatum } from '../../../../src/ui/axis/types';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 const canvas = new Canvas({

--- a/__tests__/unit/ui/axis/helix-spec.ts
+++ b/__tests__/unit/ui/axis/helix-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Helix } from '../../../../src';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 describe('linear', () => {
   test('basic', async () => {});

--- a/__tests__/unit/ui/axis/linear-spec.ts
+++ b/__tests__/unit/ui/axis/linear-spec.ts
@@ -5,11 +5,7 @@ import { createDiv } from '../../../utils';
 import type { StyleState as State } from '../../../../src/types';
 import type { TickDatum } from '../../../../src/ui/axis/types';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 const canvas = new Canvas({

--- a/__tests__/unit/ui/axis/overlap/is-overlap-spec.ts
+++ b/__tests__/unit/ui/axis/overlap/is-overlap-spec.ts
@@ -1,6 +1,7 @@
 import { Text, Rect } from '@antv/g';
 import { getBoundsCenter } from '../../../../../src/ui/axis/utils';
 import { getCollisionText, isTextOverlap } from '../../../../../src/ui/axis/overlap/is-overlap';
+import { TEXT_INHERITABLE_PROPS } from '../../../../../src';
 
 type Margin = [number, number, number, number];
 
@@ -157,6 +158,7 @@ describe('isOverlap', () => {
   test('collision', () => {
     const text1 = new Text({
       attrs: {
+        ...TEXT_INHERITABLE_PROPS,
         x: 0,
         y: 0,
         text: 'text1',
@@ -167,6 +169,7 @@ describe('isOverlap', () => {
     });
     const text2 = new Text({
       attrs: {
+        ...TEXT_INHERITABLE_PROPS,
         x: 0,
         y: 0,
         text: 'text2',
@@ -195,6 +198,7 @@ describe('isOverlap', () => {
     // 测试旋转情况下的碰撞
     const text1 = new Text({
       attrs: {
+        ...TEXT_INHERITABLE_PROPS,
         x: 0,
         y: 0,
         text: 'text',
@@ -205,6 +209,7 @@ describe('isOverlap', () => {
     });
     const text2 = new Text({
       attrs: {
+        ...TEXT_INHERITABLE_PROPS,
         x: 0,
         y: 0,
         text: 'text',

--- a/__tests__/unit/ui/breadcrumb/index-spec.ts
+++ b/__tests__/unit/ui/breadcrumb/index-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Breadcrumb } from '../../../../src';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 describe('breadcrumb', () => {
   test('basic', async () => {

--- a/__tests__/unit/ui/button/disabled-spec.ts
+++ b/__tests__/unit/ui/button/disabled-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Button } from '../../../../src';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 describe('disabled button', () => {
   test('disable', async () => {

--- a/__tests__/unit/ui/button/index-spec.ts
+++ b/__tests__/unit/ui/button/index-spec.ts
@@ -4,11 +4,7 @@ import { Button } from '../../../../src';
 import type { RectProps, TextProps } from '../../../../src/types';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 describe('button', () => {
   test('basic', async () => {

--- a/__tests__/unit/ui/checkbox/index-spec.ts
+++ b/__tests__/unit/ui/checkbox/index-spec.ts
@@ -4,11 +4,7 @@ import { Checkbox } from '../../../../src/ui/checkbox';
 import { Text } from '../../../../src/ui/text';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 const div = createDiv();
 
 const canvas = new Canvas({

--- a/__tests__/unit/ui/countdown/index-spec.ts
+++ b/__tests__/unit/ui/countdown/index-spec.ts
@@ -4,11 +4,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Countdown } from '../../../../src';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const nowDate = Date.now();
 

--- a/__tests__/unit/ui/crosshair/line-crosshair-spec.ts
+++ b/__tests__/unit/ui/crosshair/line-crosshair-spec.ts
@@ -4,11 +4,7 @@ import { LineCrosshair } from '../../../../src';
 import { createDiv } from '../../../utils';
 import { delay } from '../../../utils/delay';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/legend/category-item-spec.ts
+++ b/__tests__/unit/ui/legend/category-item-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { CategoryItem } from '../../../../src/ui/legend/category-item';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 const canvas = new Canvas({

--- a/__tests__/unit/ui/legend/category-spec.ts
+++ b/__tests__/unit/ui/legend/category-spec.ts
@@ -43,11 +43,7 @@ const items = [
   { name: 'Others', value: '0.59%' },
 ];
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 const canvas = new Canvas({

--- a/__tests__/unit/ui/legend/continuous-spec.ts
+++ b/__tests__/unit/ui/legend/continuous-spec.ts
@@ -5,11 +5,7 @@ import { createDiv } from '../../../utils';
 
 // const webglRenderer = new WebGLRenderer();
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/legend/vertical-continuous-spec.ts
+++ b/__tests__/unit/ui/legend/vertical-continuous-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Continuous } from '../../../../src/ui/legend';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/marker/index-spec.ts
+++ b/__tests__/unit/ui/marker/index-spec.ts
@@ -4,11 +4,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Marker, svg2marker } from '../../../../src';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/page-navigator/index-spec.ts
+++ b/__tests__/unit/ui/page-navigator/index-spec.ts
@@ -2,7 +2,7 @@ import { Canvas, Text, Group, Rect } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { PageNavigator } from '../../../../src';
 import { createDiv } from '../../../utils';
-import { getShapeSpace } from '../../../../src/util';
+import { getShapeSpace, TEXT_INHERITABLE_PROPS } from '../../../../src/util';
 
 const renderer = new CanvasRenderer({
   enableDirtyRectangleRenderingDebug: false,
@@ -37,6 +37,7 @@ function createPages(count: number, width: number, height: number) {
     });
     const text = new Text({
       style: {
+        ...TEXT_INHERITABLE_PROPS,
         x: width / 2,
         y: height / 2,
         text: `第${i}页`,

--- a/__tests__/unit/ui/page-navigator/index-spec.ts
+++ b/__tests__/unit/ui/page-navigator/index-spec.ts
@@ -4,11 +4,7 @@ import { PageNavigator } from '../../../../src';
 import { createDiv } from '../../../utils';
 import { getShapeSpace, TEXT_INHERITABLE_PROPS } from '../../../../src/util';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/page-navigator/vertical-spec.ts
+++ b/__tests__/unit/ui/page-navigator/vertical-spec.ts
@@ -2,7 +2,7 @@ import { Canvas, Text, Group, Rect } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { PageNavigator } from '../../../../src';
 import { createDiv } from '../../../utils';
-import { getShapeSpace } from '../../../../src/util';
+import { getShapeSpace, TEXT_INHERITABLE_PROPS } from '../../../../src/util';
 
 const renderer = new CanvasRenderer({
   enableDirtyRectangleRenderingDebug: false,
@@ -37,6 +37,7 @@ function createPages(count: number, width: number, height: number) {
     });
     const text = new Text({
       style: {
+        ...TEXT_INHERITABLE_PROPS,
         x: width / 2,
         y: height / 2,
         text: `第${i}页`,

--- a/__tests__/unit/ui/page-navigator/vertical-spec.ts
+++ b/__tests__/unit/ui/page-navigator/vertical-spec.ts
@@ -4,11 +4,7 @@ import { PageNavigator } from '../../../../src';
 import { createDiv } from '../../../utils';
 import { getShapeSpace, TEXT_INHERITABLE_PROPS } from '../../../../src/util';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/scrollbar/index-spec.ts
+++ b/__tests__/unit/ui/scrollbar/index-spec.ts
@@ -13,11 +13,7 @@ const clamp = (value: number, min: number, max: number) => {
   return value;
 };
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/slider/index-spec.ts
+++ b/__tests__/unit/ui/slider/index-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Slider } from '../../../../src';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/sparkline/index-spec.ts
+++ b/__tests__/unit/ui/sparkline/index-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Sparkline } from '../../../../src';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/statistic/index-spec.ts
+++ b/__tests__/unit/ui/statistic/index-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Statistic, Tag } from '../../../../src';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const initTitleText = 'basic statistic title';
 const initValueText = 'basic statistic value';

--- a/__tests__/unit/ui/switch/index-spec.ts
+++ b/__tests__/unit/ui/switch/index-spec.ts
@@ -5,11 +5,7 @@ import { Switch } from '../../../../src';
 import { SIZE_STYLE } from '../../../../src/ui/switch/constant';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 describe('switch', () => {
   const div = createDiv();

--- a/__tests__/unit/ui/tag/index-spec.ts
+++ b/__tests__/unit/ui/tag/index-spec.ts
@@ -4,11 +4,7 @@ import { head, last } from '@antv/util';
 import { Tag } from '../../../../src';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 describe('tag', () => {
   const div = createDiv();

--- a/__tests__/unit/ui/text/decoration-spec.ts
+++ b/__tests__/unit/ui/text/decoration-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Decoration } from '../../../../src/ui/text/decoration';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/text/index-spec.ts
+++ b/__tests__/unit/ui/text/index-spec.ts
@@ -4,11 +4,7 @@ import { Text } from '../../../../src';
 import { createDiv } from '../../../utils';
 import { TEXT_INHERITABLE_PROPS } from '../../../../src/util';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/text/index-spec.ts
+++ b/__tests__/unit/ui/text/index-spec.ts
@@ -2,6 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Text } from '../../../../src';
 import { createDiv } from '../../../utils';
+import { TEXT_INHERITABLE_PROPS } from '../../../../src/util';
 
 const renderer = new CanvasRenderer({
   enableDirtyRectangleRenderingDebug: false,
@@ -20,6 +21,7 @@ const canvas = new Canvas({
 
 const text = new Text({
   style: {
+    ...TEXT_INHERITABLE_PROPS,
     x: 100,
     y: 10,
     text: 'ABDPabdp\nABDASDPabdp\nABDPabdp',
@@ -84,7 +86,7 @@ describe('text', () => {
   });
   test('background', () => {
     // @ts-ignore
-    expect(text.backgroundShape.attr('stroke')).toBe('transparent');
+    expect(text.backgroundShape.attr('stroke')).toBe('');
     text.update({
       backgroundStyle: {
         lineWidth: 1,

--- a/__tests__/unit/ui/timeline/axis-spec.ts
+++ b/__tests__/unit/ui/timeline/axis-spec.ts
@@ -4,11 +4,7 @@ import { SliderAxis } from '../../../../src/ui/timeline/slider-axis';
 import { CellAxis } from '../../../../src/ui/timeline/cell-axis';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 const div = createDiv();
 
 const canvas = new Canvas({

--- a/__tests__/unit/ui/timeline/index-spec.ts
+++ b/__tests__/unit/ui/timeline/index-spec.ts
@@ -7,11 +7,7 @@ function getVerticalCenter(shape: DisplayObject | undefined) {
   return shape?.getBounds()?.center[1] as number;
 }
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 const div = createDiv();
 
 const canvas = new Canvas({

--- a/__tests__/unit/ui/timeline/speedcontrol-spec.ts
+++ b/__tests__/unit/ui/timeline/speedcontrol-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { SpeedControl } from '../../../../src/ui/timeline/speedcontrol';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 const div = createDiv();
 
 const canvas = new Canvas({

--- a/__tests__/unit/ui/tooltip/custom-spec.ts
+++ b/__tests__/unit/ui/tooltip/custom-spec.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Tooltip, Sparkline } from '../../../../src';
 import { createDiv } from '../../../utils';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const div = createDiv();
 

--- a/__tests__/unit/ui/tooltip/index-spec.ts
+++ b/__tests__/unit/ui/tooltip/index-spec.ts
@@ -7,11 +7,7 @@ Array.from(document.getElementsByClassName('tooltip')).forEach((tooltip) => {
   tooltip.remove();
 });
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 const div = createDiv();
 const canvas = new Canvas({
   container: div,

--- a/__tests__/unit/ui/tooltip/mini-spec.ts
+++ b/__tests__/unit/ui/tooltip/mini-spec.ts
@@ -7,11 +7,7 @@ Array.from(document.getElementsByClassName('tooltip')).forEach((tooltip) => {
   tooltip.remove();
 });
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 const div = createDiv();
 const canvas = new Canvas({
   container: div,

--- a/examples/basic-ui/button/demo/custom-button.ts
+++ b/examples/basic-ui/button/demo/custom-button.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Button, Marker } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/button/demo/disabled-button.ts
+++ b/examples/basic-ui/button/demo/disabled-button.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Button } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/button/demo/marker-button.ts
+++ b/examples/basic-ui/button/demo/marker-button.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Button, Marker } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/button/demo/simple-button.ts
+++ b/examples/basic-ui/button/demo/simple-button.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Button } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/marker/demo/register-svg-symbol.ts
+++ b/examples/basic-ui/marker/demo/register-svg-symbol.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Marker, svg2marker } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/marker/demo/register-symbol.ts
+++ b/examples/basic-ui/marker/demo/register-symbol.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Marker } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/marker/demo/triangle.ts
+++ b/examples/basic-ui/marker/demo/triangle.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Marker } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/switch/demo/checked-switch.ts
+++ b/examples/basic-ui/switch/demo/checked-switch.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Switch, Button } from '@antv/gui';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/switch/demo/children-switch.ts
+++ b/examples/basic-ui/switch/demo/children-switch.ts
@@ -25,11 +25,7 @@ Marker.registerSymbol('stop', (x, y, r) => {
   ];
 });
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/switch/demo/simple.ts
+++ b/examples/basic-ui/switch/demo/simple.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Switch } from '@antv/gui';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/switch/demo/size-switch.ts
+++ b/examples/basic-ui/switch/demo/size-switch.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Switch, Marker } from '@antv/gui';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/tag/demo/background-style.ts
+++ b/examples/basic-ui/tag/demo/background-style.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Tag } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/tag/demo/basic.ts
+++ b/examples/basic-ui/tag/demo/basic.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Tag } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/tag/demo/colorful.ts
+++ b/examples/basic-ui/tag/demo/colorful.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Tag } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/tag/demo/marker.ts
+++ b/examples/basic-ui/tag/demo/marker.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Marker, Tag } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/tag/demo/text-style.ts
+++ b/examples/basic-ui/tag/demo/text-style.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Tag } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/text/demo/basic.ts
+++ b/examples/basic-ui/text/demo/basic.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Text } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/basic-ui/toolbox/demo/basic.ts
+++ b/examples/basic-ui/toolbox/demo/basic.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Toolbox } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/axis/demo/arc.ts
+++ b/examples/chart-ui/axis/demo/arc.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Arc } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/axis/demo/label-formatter.ts
+++ b/examples/chart-ui/axis/demo/label-formatter.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Linear } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/axis/demo/label-layout.ts
+++ b/examples/chart-ui/axis/demo/label-layout.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Linear } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/axis/demo/linear.ts
+++ b/examples/chart-ui/axis/demo/linear.ts
@@ -4,11 +4,7 @@ import { Band as BandScale } from '@antv/scale';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Linear as LinearAxis, wrapper } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/axis/demo/style.ts
+++ b/examples/chart-ui/axis/demo/style.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Linear } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/axis/demo/time-axis.ts
+++ b/examples/chart-ui/axis/demo/time-axis.ts
@@ -2,11 +2,7 @@ import { Canvas, Rect } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Linear } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/axis/demo/vertical-axis.ts
+++ b/examples/chart-ui/axis/demo/vertical-axis.ts
@@ -4,11 +4,7 @@ import { Linear as LinearScale } from '@antv/scale';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Linear as LinearAxis } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/crosshair/demo/circle.ts
+++ b/examples/chart-ui/crosshair/demo/circle.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { CircleCrosshair } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/crosshair/demo/line.ts
+++ b/examples/chart-ui/crosshair/demo/line.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { LineCrosshair } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/crosshair/demo/polygon.ts
+++ b/examples/chart-ui/crosshair/demo/polygon.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { PolygonCrosshair } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/basic-category.ts
+++ b/examples/chart-ui/legend/demo/basic-category.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Category } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/basic-continuous.ts
+++ b/examples/chart-ui/legend/demo/basic-continuous.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Continuous } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/category-event.ts
+++ b/examples/chart-ui/legend/demo/category-event.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Category } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/category-marker.ts
+++ b/examples/chart-ui/legend/demo/category-marker.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Category } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/category-pagination.ts
+++ b/examples/chart-ui/legend/demo/category-pagination.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Category } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/category-style.ts
+++ b/examples/chart-ui/legend/demo/category-style.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Category } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/continuous-color.ts
+++ b/examples/chart-ui/legend/demo/continuous-color.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Continuous } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/continuous-event.ts
+++ b/examples/chart-ui/legend/demo/continuous-event.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Continuous } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/continuous-labels.ts
+++ b/examples/chart-ui/legend/demo/continuous-labels.ts
@@ -2,11 +2,7 @@ import { Canvas, Group } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Continuous } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/handle.ts
+++ b/examples/chart-ui/legend/demo/handle.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Continuous } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/indicator.ts
+++ b/examples/chart-ui/legend/demo/indicator.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Continuous } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/rail-shape.ts
+++ b/examples/chart-ui/legend/demo/rail-shape.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Continuous } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/legend/demo/various-continuous.ts
+++ b/examples/chart-ui/legend/demo/various-continuous.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { deepMix } from '@antv/util';
 import { Continuous } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/poptip/demo/axis-poptip.ts
+++ b/examples/chart-ui/poptip/demo/axis-poptip.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Poptip, Linear } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/poptip/demo/basic-poptip.ts
+++ b/examples/chart-ui/poptip/demo/basic-poptip.ts
@@ -2,11 +2,7 @@ import { Canvas, Rect, Circle, Text } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Poptip } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/poptip/demo/content-poptip.ts
+++ b/examples/chart-ui/poptip/demo/content-poptip.ts
@@ -2,11 +2,7 @@ import { Canvas, Rect } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Poptip } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/poptip/demo/legend-poptip.ts
+++ b/examples/chart-ui/poptip/demo/legend-poptip.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Category, Continuous, Poptip } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/poptip/demo/more-direction-poptip.ts
+++ b/examples/chart-ui/poptip/demo/more-direction-poptip.ts
@@ -2,11 +2,7 @@ import { Canvas, Rect, Circle } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Poptip } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/poptip/demo/poptip-domStyles.ts
+++ b/examples/chart-ui/poptip/demo/poptip-domStyles.ts
@@ -2,11 +2,7 @@ import { Canvas, Circle, Text } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Poptip } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/scrollbar/demo/basic.ts
+++ b/examples/chart-ui/scrollbar/demo/basic.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Scrollbar } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/scrollbar/demo/event.ts
+++ b/examples/chart-ui/scrollbar/demo/event.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Scrollbar } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/scrollbar/demo/more.ts
+++ b/examples/chart-ui/scrollbar/demo/more.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Scrollbar } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/scrollbar/demo/style.ts
+++ b/examples/chart-ui/scrollbar/demo/style.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Scrollbar } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/slider/demo/basic.ts
+++ b/examples/chart-ui/slider/demo/basic.ts
@@ -2,11 +2,7 @@ import { Canvas, Rect } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Slider } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/slider/demo/event.ts
+++ b/examples/chart-ui/slider/demo/event.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Slider } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/slider/demo/handle.ts
+++ b/examples/chart-ui/slider/demo/handle.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Slider } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/slider/demo/sparkline.ts
+++ b/examples/chart-ui/slider/demo/sparkline.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Slider } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/slider/demo/style.ts
+++ b/examples/chart-ui/slider/demo/style.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Slider } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/tooltip/demo/basic-tooltip.ts
+++ b/examples/chart-ui/tooltip/demo/basic-tooltip.ts
@@ -2,11 +2,7 @@ import { Canvas, Rect, Circle } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Tooltip } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/tooltip/demo/custom-tooltip.ts
+++ b/examples/chart-ui/tooltip/demo/custom-tooltip.ts
@@ -2,11 +2,7 @@ import { Canvas, Rect } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Tooltip, Sparkline } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/chart-ui/tooltip/demo/mini-tooltip.ts
+++ b/examples/chart-ui/tooltip/demo/mini-tooltip.ts
@@ -2,11 +2,7 @@ import { Canvas, Rect, Circle } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Tooltip } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/others/page-navigator/demo/basic-page-navigator.ts
+++ b/examples/others/page-navigator/demo/basic-page-navigator.ts
@@ -2,11 +2,7 @@ import { Canvas, Text, Rect, Group } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { PageNavigator } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/others/page-navigator/demo/vertical-page-navigator.ts
+++ b/examples/others/page-navigator/demo/vertical-page-navigator.ts
@@ -2,11 +2,7 @@ import { Canvas, Text, Rect, Group } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { PageNavigator } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/others/sparkline/demo/area-sparkline.ts
+++ b/examples/others/sparkline/demo/area-sparkline.ts
@@ -2,11 +2,7 @@ import { Canvas, Rect, Text } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Sparkline } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 function random(min, max) {
   var range = max - min;

--- a/examples/others/sparkline/demo/area-stack-sparkline.ts
+++ b/examples/others/sparkline/demo/area-stack-sparkline.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Sparkline } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/others/sparkline/demo/basic-sparkbar.ts
+++ b/examples/others/sparkline/demo/basic-sparkbar.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Sparkline } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/others/sparkline/demo/basic-sparkline.ts
+++ b/examples/others/sparkline/demo/basic-sparkline.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Sparkline } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/others/sparkline/demo/stack-sparkbar.ts
+++ b/examples/others/sparkline/demo/stack-sparkbar.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Sparkline } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/wip/breadcrumb/demo/auto-wrap.ts
+++ b/examples/wip/breadcrumb/demo/auto-wrap.ts
@@ -3,11 +3,7 @@ import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Breadcrumb } from '@antv/gui';
 import * as dat from 'dat.gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/wip/breadcrumb/demo/basic.ts
+++ b/examples/wip/breadcrumb/demo/basic.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Breadcrumb } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/wip/breadcrumb/demo/custom-seperator.ts
+++ b/examples/wip/breadcrumb/demo/custom-seperator.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Breadcrumb } from '@antv/gui';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/wip/statistic/demo/countdown-format.ts
+++ b/examples/wip/statistic/demo/countdown-format.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Countdown } from '@antv/gui';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 // @ts-ignore
 const canvas = new Canvas({

--- a/examples/wip/statistic/demo/countdown.ts
+++ b/examples/wip/statistic/demo/countdown.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Countdown } from '@antv/gui';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 // @ts-ignore
 const canvas = new Canvas({

--- a/examples/wip/statistic/demo/simple.ts
+++ b/examples/wip/statistic/demo/simple.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Statistic } from '@antv/gui';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 const canvas = new Canvas({
   container: 'container',

--- a/examples/wip/statistic/demo/with-marker.ts
+++ b/examples/wip/statistic/demo/with-marker.ts
@@ -2,11 +2,7 @@ import { Canvas } from '@antv/g';
 import { Statistic } from '@antv/gui';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 
-const renderer = new CanvasRenderer({
-  enableDirtyRectangleRenderingDebug: false,
-  enableAutoRendering: true,
-  enableDirtyRectangleRendering: true,
-});
+const renderer = new CanvasRenderer();
 
 // @ts-ignore
 const canvas = new Canvas({

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
   ],
   "dependencies": {
     "@antv/dom-util": "^2.0.3",
-    "@antv/g": "^5.0.1",
-    "@antv/g-canvas": "^1.0.1",
-    "@antv/g-svg": "^1.0.1",
+    "@antv/g": "latest",
+    "@antv/g-canvas": "latest",
+    "@antv/g-svg": "latest",
     "@antv/matrix-util": "^3.0.4",
     "@antv/path-util": "^2.0.15",
     "@antv/scale": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "dist/gui.min.js",
-      "limit": "390 Kb"
+      "limit": "400 Kb"
     }
   ],
   "author": {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
   ],
   "dependencies": {
     "@antv/dom-util": "^2.0.3",
-    "@antv/g": "latest",
-    "@antv/g-canvas": "latest",
-    "@antv/g-svg": "latest",
+    "@antv/g": "^5.0.21",
+    "@antv/g-canvas": "^1.0.20",
+    "@antv/g-svg": "^1.0.18",
     "@antv/matrix-util": "^3.0.4",
     "@antv/path-util": "^2.0.15",
     "@antv/scale": "^0.4.3",

--- a/src/ui/axis/base.ts
+++ b/src/ui/axis/base.ts
@@ -17,10 +17,9 @@ import type {
   AxisSubTickLineCfg,
 } from './types';
 import type { ShapeAttrs, StyleState as State, TextProps, PathProps } from '../../types';
-import type { TimeScale } from '../../util';
-import { GUI } from '../../core/gui';
-import { Marker } from '../marker';
 import {
+  TEXT_INHERITABLE_PROPS,
+  TimeScale,
   getFont,
   getMask,
   formatTime,
@@ -35,6 +34,8 @@ import {
   toScientificNotation,
   scale as timeScale,
 } from '../../util';
+import { GUI } from '../../core/gui';
+import { Marker } from '../marker';
 import { getVectorsAngle, centerRotate, formatAngle } from './utils';
 import { AXIS_BASE_DEFAULT_OPTIONS, NULL_ARROW, NULL_TEXT, COMMON_TIME_MAP } from './constant';
 import { isLabelsOverlap } from './overlap/is-overlap';
@@ -160,6 +161,7 @@ export abstract class AxisBase<T extends AxisBaseCfg> extends GUI<Required<T>> {
     // 获取title
     const [x, y] = this.getValuePoint(titleVal);
     return {
+      ...TEXT_INHERITABLE_PROPS,
       x: x + ox,
       y: y + oy,
       text: content,
@@ -451,6 +453,7 @@ export abstract class AxisBase<T extends AxisBaseCfg> extends GUI<Required<T>> {
     this.titleShape = new Text({
       name: 'title',
       style: {
+        ...TEXT_INHERITABLE_PROPS,
         text: dftAxisTitle ? dftAxisTitle.content ?? '' : '',
       },
     });
@@ -594,7 +597,10 @@ export abstract class AxisBase<T extends AxisBaseCfg> extends GUI<Required<T>> {
       this.labelsGroup.appendChild(
         new Text({
           name: 'label',
-          style,
+          style: {
+            ...TEXT_INHERITABLE_PROPS,
+            ...style,
+          },
         })
       );
     });

--- a/src/ui/axis/constant.ts
+++ b/src/ui/axis/constant.ts
@@ -1,4 +1,5 @@
 import { deepMix } from '@antv/util';
+import { TEXT_INHERITABLE_PROPS } from '../../util/style';
 import type { AxisBaseOptions, TickDatum } from './types';
 
 export const AXIS_BASE_DEFAULT_OPTIONS: AxisBaseOptions = {
@@ -6,6 +7,7 @@ export const AXIS_BASE_DEFAULT_OPTIONS: AxisBaseOptions = {
     title: {
       content: '',
       style: {
+        ...TEXT_INHERITABLE_PROPS,
         fontSize: 12,
         fill: '#2C3542',
         fillOpacity: 0.45,

--- a/src/ui/breadcrumb/index.ts
+++ b/src/ui/breadcrumb/index.ts
@@ -1,7 +1,7 @@
 import { DisplayObject, Group, Text } from '@antv/g';
 import { deepMix, isNil, pick } from '@antv/util';
 import { GUI } from '../../core/gui';
-import { normalPadding } from '../../util';
+import { normalPadding, TEXT_INHERITABLE_PROPS } from '../../util';
 import { Tag } from '../tag';
 import type { BreadcrumbCfg, BreadcrumbOptions, BreadcrumbItem } from './type';
 
@@ -29,6 +29,7 @@ export class Breadcrumb extends GUI<Required<BreadcrumbCfg>> {
       },
       textStyle: {
         default: {
+          ...TEXT_INHERITABLE_PROPS,
           fontSize: 14,
           fill: 'rgba(0, 0, 0, 0.45)',
         },
@@ -139,6 +140,7 @@ export class Breadcrumb extends GUI<Required<BreadcrumbCfg>> {
       name: `${Breadcrumb.tag}-separator`,
       id: `${Breadcrumb.tag}-separator-${idx}`,
       style: {
+        ...TEXT_INHERITABLE_PROPS,
         x: this.cursorX + spacing!,
         y: this.cursorY,
         ...style,

--- a/src/ui/button/index.ts
+++ b/src/ui/button/index.ts
@@ -2,7 +2,14 @@ import { Rect, Text } from '@antv/g';
 import { deepMix, get, isUndefined } from '@antv/util';
 import { GUI } from '../../core/gui';
 import { SIZE_STYLE, TYPE_STYLE, DISABLED_STYLE } from './constant';
-import { deepAssign, getEllipsisText, measureTextWidth, getFont, getStateStyle } from '../../util';
+import {
+  deepAssign,
+  getEllipsisText,
+  measureTextWidth,
+  getFont,
+  getStateStyle,
+  TEXT_INHERITABLE_PROPS,
+} from '../../util';
 import { Marker } from '../marker';
 import type { ButtonCfg, ButtonOptions, IMarkerCfg } from './types';
 import type { TextProps, RectProps } from '../../types';
@@ -31,6 +38,7 @@ export class Button extends GUI<ButtonCfg> {
       markerSpacing: 5,
       textStyle: {
         default: {
+          ...TEXT_INHERITABLE_PROPS,
           textAlign: 'center',
           textBaseline: 'middle',
         },

--- a/src/ui/checkbox/constant.ts
+++ b/src/ui/checkbox/constant.ts
@@ -1,8 +1,10 @@
 import { RectStyleProps } from '@antv/g';
+import { TEXT_INHERITABLE_PROPS } from '../../util';
 import { LabelProps } from '../../types';
 
 // 默认文本样式
 export const LABEL_TEXT_STYLE = {
+  ...TEXT_INHERITABLE_PROPS,
   stroke: 'rgba(0,0,0,0.45)',
   fontSize: 10,
   lineHeight: 16,

--- a/src/ui/legend/base.ts
+++ b/src/ui/legend/base.ts
@@ -1,7 +1,7 @@
 import { deepMix, get } from '@antv/util';
 import { Rect, Text } from '@antv/g';
 import { GUI } from '../../core/gui';
-import { getStateStyle, normalPadding, getShapeSpace } from '../../util';
+import { getStateStyle, normalPadding, getShapeSpace, TEXT_INHERITABLE_PROPS } from '../../util';
 import { LEGEND_BASE_DEFAULT_OPTIONS } from './constant';
 import type { Pair } from '../slider/types';
 import type { StyleState, RectProps } from '../../types';
@@ -41,6 +41,7 @@ export abstract class LegendBase<T extends LegendBaseCfg> extends GUI<Required<T
     const { content, style, formatter } = title!;
 
     return {
+      ...TEXT_INHERITABLE_PROPS,
       ...style,
       text: formatter!(content!),
     };

--- a/src/ui/legend/category-item.ts
+++ b/src/ui/legend/category-item.ts
@@ -3,7 +3,7 @@ import { deepMix, get, max } from '@antv/util';
 import { GUI } from '../../core/gui';
 import { Marker } from '../marker';
 import { NAME_VALUE_RATIO } from './constant';
-import { getStateStyle, getEllipsisText, getFont, getShapeSpace } from '../../util';
+import { getStateStyle, getEllipsisText, getFont, getShapeSpace, TEXT_INHERITABLE_PROPS } from '../../util';
 import type { DisplayObjectConfig, StyleState, ShapeAttrs } from '../../types';
 import type { CategoryItemCfg as ItemCfg, State } from './types';
 
@@ -35,13 +35,14 @@ export class CategoryItem extends GUI<ICategoryItemCfg> {
   private get nameShapeCfg() {
     const { itemName } = this.attributes;
     const { content: nameContent } = itemName;
-    return { text: nameContent, ...this.getStyle(['itemName', 'style']) };
+    return { fontSize: 12, text: nameContent, ...this.getStyle(['itemName', 'style']) };
   }
 
   private get valueShapeCfg() {
     const { itemValue } = this.attributes;
     const { content: valueContent } = itemValue;
     return {
+      fontSize: 12,
       text: valueContent,
       ...this.getStyle(['itemValue', 'style']),
     };
@@ -80,13 +81,19 @@ export class CategoryItem extends GUI<ICategoryItemCfg> {
     // render nameShape
     this.nameShape = new Text({
       name: 'name',
-      style: this.nameShapeCfg,
+      style: {
+        ...TEXT_INHERITABLE_PROPS,
+        ...this.nameShapeCfg,
+      },
     });
     this.backgroundShape.appendChild(this.nameShape);
     // render valueShape
     this.valueShape = new Text({
       name: 'value',
-      style: this.valueShapeCfg,
+      style: {
+        ...TEXT_INHERITABLE_PROPS,
+        ...this.valueShapeCfg,
+      },
     });
     this.backgroundShape.appendChild(this.valueShape);
     this.backgroundShape.toBack();

--- a/src/ui/legend/constant.ts
+++ b/src/ui/legend/constant.ts
@@ -1,4 +1,5 @@
 import { deepMix } from '@antv/util';
+import { TEXT_INHERITABLE_PROPS } from '../../util';
 
 export const LEGEND_BASE_DEFAULT_OPTIONS = {
   style: {
@@ -17,6 +18,7 @@ export const LEGEND_BASE_DEFAULT_OPTIONS = {
       spacing: 4,
       align: 'left',
       style: {
+        ...TEXT_INHERITABLE_PROPS,
         fill: '#2C3542',
         fillOpacity: 0.45,
         fontSize: 12,

--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -6,7 +6,7 @@ import { Marker } from '../marker';
 import { LegendBase } from './base';
 import { getValueOffset, getStepValueByValue } from './utils';
 import { CONTINUOUS_DEFAULT_OPTIONS, STEP_RATIO } from './constant';
-import { toPrecision, getShapeSpace, getEventPos, deepAssign, throttle } from '../../util';
+import { toPrecision, getShapeSpace, getEventPos, deepAssign, throttle, TEXT_INHERITABLE_PROPS } from '../../util';
 import { wrapper, WrapperNode } from '../../util/wrapper';
 import { Poptip, PoptipCfg } from '../poptip';
 import type { Pair } from '../slider/types';
@@ -142,6 +142,7 @@ export class Continuous extends LegendBase<ContinuousCfg> {
         ...markerStyle,
       },
       textCfg: {
+        ...TEXT_INHERITABLE_PROPS,
         text: '',
         opacity: label ? 1 : 0,
         ...(label?.style || {}),
@@ -469,7 +470,10 @@ export class Continuous extends LegendBase<ContinuousCfg> {
 
     const text = new Text({
       name: 'text',
-      style: textCfg,
+      style: {
+        ...TEXT_INHERITABLE_PROPS,
+        ...textCfg,
+      },
     });
     el.appendChild(text);
 

--- a/src/ui/legend/labels.ts
+++ b/src/ui/legend/labels.ts
@@ -1,6 +1,7 @@
 import { deepMix } from '@antv/util';
 import { DisplayObject, Text, Group } from '@antv/g';
 import { ShapeAttrs, TextProps } from '../../types';
+import { TEXT_INHERITABLE_PROPS } from '../../util';
 
 export interface ILabelsCfg extends ShapeAttrs {
   labels: TextProps[];
@@ -22,7 +23,10 @@ export class Labels extends DisplayObject<ILabelsCfg> {
     labels.forEach((cfg) => {
       const text = new Text({
         name: 'label',
-        style: cfg,
+        style: {
+          ...TEXT_INHERITABLE_PROPS,
+          ...cfg,
+        },
       });
       this.labelsGroup.appendChild(text);
     });

--- a/src/ui/marker/types.ts
+++ b/src/ui/marker/types.ts
@@ -6,11 +6,11 @@ export interface MarkerStyleProps extends ShapeAttrs {
   /**
    * 标记的位置 x，默认为 0
    */
-  x?: number;
+  x?: number | string;
   /**
    * 标记的位置 x，默认为 0
    */
-  y?: number;
+  y?: number | string;
   /**
    * 标记的大小，默认为 16
    */

--- a/src/ui/scrollbar/index.ts
+++ b/src/ui/scrollbar/index.ts
@@ -292,7 +292,8 @@ export class Scrollbar extends GUI<Required<ScrollbarCfg>> {
    * 点击轨道事件
    */
   private onTrackClick = (e: any) => {
-    const { x, y, thumbLen } = this.attributes;
+    const { thumbLen } = this.attributes;
+    const [x, y] = this.getLocalPosition();
     const [top, , , left] = this.padding;
     const basePos = this.getOrientVal([x + left, y + top]);
     const clickPos = this.getOrientVal(getEventPos(e)) - thumbLen / 2;

--- a/src/ui/slider/handle.ts
+++ b/src/ui/slider/handle.ts
@@ -11,7 +11,7 @@ export interface IHandleCfg {
   handleType: 'start' | 'end';
   iconCfg: (ShapeAttrs | MarkerStyleProps) & {
     size?: number;
-    radius?: number;
+    radius?: number | string;
     type: 'hide' | 'symbol' | 'default';
     orient: 'horizontal' | 'vertical';
   };

--- a/src/ui/slider/handle.ts
+++ b/src/ui/slider/handle.ts
@@ -2,6 +2,7 @@ import { DisplayObject, Rect, Line, Text } from '@antv/g';
 import { deepMix, get } from '@antv/util';
 import { Marker, MarkerStyleProps } from '../marker';
 import type { TextProps, ShapeAttrs } from '../../types';
+import { TEXT_INHERITABLE_PROPS } from '../../util';
 
 export interface IHandleCfg {
   x: number;
@@ -121,7 +122,10 @@ export class Handle extends DisplayObject<IHandleCfg> {
     const { textCfg } = this.attributes;
     return new Text({
       name: 'text',
-      style: textCfg,
+      style: {
+        ...TEXT_INHERITABLE_PROPS,
+        ...textCfg,
+      },
     });
   }
 

--- a/src/ui/slider/index.ts
+++ b/src/ui/slider/index.ts
@@ -4,7 +4,14 @@ import { deepMix, get } from '@antv/util';
 import { GUI } from '../../core/gui';
 import { Handle } from './handle';
 import { Sparkline } from '../sparkline';
-import { toPrecision, getShapeSpace, getEventPos, getStateStyle, normalPadding } from '../../util';
+import {
+  toPrecision,
+  getShapeSpace,
+  getEventPos,
+  getStateStyle,
+  normalPadding,
+  TEXT_INHERITABLE_PROPS,
+} from '../../util';
 import type { MarkerStyleProps } from '../marker';
 import type { SparklineCfg } from '../sparkline';
 import type { IHandleCfg } from './handle';
@@ -56,6 +63,7 @@ export class Slider extends GUI<SliderCfg> {
         formatter: (val: string, value: number) => val,
         spacing: 10,
         textStyle: {
+          ...TEXT_INHERITABLE_PROPS,
           fill: '#000',
           fillOpacity: 0.45,
           fontSize: 12,

--- a/src/ui/tag/index.ts
+++ b/src/ui/tag/index.ts
@@ -1,7 +1,7 @@
 import { Rect, RectStyleProps, Text, TextStyleProps } from '@antv/g';
 import { deepMix } from '@antv/util';
 import { GUI } from '../../core/gui';
-import { getStateStyle as getStyle, normalPadding, getShapeSpace } from '../../util';
+import { getStateStyle as getStyle, normalPadding, getShapeSpace, TEXT_INHERITABLE_PROPS } from '../../util';
 import { Marker, MarkerStyleProps } from '../marker';
 import type { TagStyleProps, TagOptions } from './types';
 
@@ -59,6 +59,7 @@ export class Tag extends GUI<Required<TagStyleProps>> {
       verticalAlign: 'top',
       textStyle: {
         default: {
+          ...TEXT_INHERITABLE_PROPS,
           fontSize: 12,
           textAlign: 'start',
           textBaseline: 'middle',

--- a/src/ui/text/index.ts
+++ b/src/ui/text/index.ts
@@ -1,7 +1,14 @@
 import { Text as GText, Rect, Group } from '@antv/g';
 import { pick, max, isNumber } from '@antv/util';
 import { Decoration } from './decoration';
-import { deepAssign, transform, getEllipsisText, getShapeSpace, measureTextWidth } from '../../util';
+import {
+  deepAssign,
+  transform,
+  getEllipsisText,
+  getShapeSpace,
+  measureTextWidth,
+  TEXT_INHERITABLE_PROPS,
+} from '../../util';
 import { GUI } from '../../core/gui';
 import type { TextCfg, TextOptions, DecorationCfg } from './types';
 import type { TextProps } from '../../types';
@@ -173,6 +180,7 @@ export class Text extends GUI<Required<TextCfg>> {
   private get textCfg(): TextProps {
     const { renderText, lineHeight, wordWrap, wordWrapWidth, fontColor: fill } = this;
     return {
+      ...TEXT_INHERITABLE_PROPS,
       ...this.font,
       fill,
       wordWrap,

--- a/src/ui/timeline/slider-axis.ts
+++ b/src/ui/timeline/slider-axis.ts
@@ -212,11 +212,11 @@ export class SliderAxis extends GUI<Required<SliderAxisCfg>> {
     );
     if (this.animation) {
       this.animation.onframe = () => {
-        this.endHandleShape?.attr({ x: this.selectionShape.parsedStyle.width.value as number });
+        this.endHandleShape?.attr({ x: this.selectionShape.parsedStyle?.width?.value });
       };
       this.animation.onfinish = () => {
         const newSelection = this.calculateSelection() as [string, string];
-        this.endHandleShape?.attr({ x: this.selectionShape.parsedStyle.width.value as number });
+        this.endHandleShape?.attr({ x: this.selectionShape.parsedStyle?.width?.value });
         this.attr({ selection: newSelection });
         isFunction(onSelectionChange) && onSelectionChange([selection[0], timeData[newEndIdx].date]);
       };

--- a/src/ui/timeline/speedcontrol.ts
+++ b/src/ui/timeline/speedcontrol.ts
@@ -1,6 +1,7 @@
 import { Group, Path, PathCommand, Rect } from '@antv/g';
 import { deepMix, isFunction } from '@antv/util';
 import { GUIOption } from 'types';
+import { TEXT_INHERITABLE_PROPS } from 'util';
 import { Text } from '../text';
 import { GUI } from '../../core/gui';
 import { SpeedControlCfg, SpeedControlOptions } from './types';
@@ -136,6 +137,7 @@ export class SpeedControl extends GUI<Required<SpeedControlCfg>> {
     restSpacing = restSpacing > 0 ? restSpacing : 0;
     this.labelShape = new Text({
       style: {
+        ...TEXT_INHERITABLE_PROPS,
         ...(label as any),
         x: 10 + spacing,
         width: restSpacing,

--- a/src/ui/timeline/speedcontrol.ts
+++ b/src/ui/timeline/speedcontrol.ts
@@ -1,7 +1,7 @@
 import { Group, Path, PathCommand, Rect } from '@antv/g';
 import { deepMix, isFunction } from '@antv/util';
 import { GUIOption } from 'types';
-import { TEXT_INHERITABLE_PROPS } from 'util';
+import { TEXT_INHERITABLE_PROPS } from '../../util';
 import { Text } from '../text';
 import { GUI } from '../../core/gui';
 import { SpeedControlCfg, SpeedControlOptions } from './types';

--- a/src/ui/toolbox/index.ts
+++ b/src/ui/toolbox/index.ts
@@ -1,6 +1,6 @@
 import { DisplayObject, Group, Rect, Text } from '@antv/g';
 import { GUIOption } from 'types';
-import { deepAssign } from '../../util';
+import { deepAssign, TEXT_INHERITABLE_PROPS } from '../../util';
 import { GUI } from '../../core/gui';
 import { FeatureCtor, ToolboxCfg, ToolboxOptions } from './types';
 import { download, reset, reload } from './items';
@@ -21,6 +21,7 @@ class Toolbox extends GUI<ToolboxCfg> {
       spacing: 8,
       features: [],
       textStyle: {
+        ...TEXT_INHERITABLE_PROPS,
         fill: 'rgba(0,0,0,0.65)',
         textBaseline: 'top',
         textAlign: 'center',

--- a/src/ui/toolbox/items/download.ts
+++ b/src/ui/toolbox/items/download.ts
@@ -9,6 +9,7 @@ export const download = ({ size = 24, stroke = '#363636' }): DisplayObject => {
       y: 0,
       lineWidth: 1,
       stroke,
+      transformOrigin: 'center',
       path: [
         ['M', 11.5, 2],
         ['L', 11.5, 17],
@@ -23,7 +24,6 @@ export const download = ({ size = 24, stroke = '#363636' }): DisplayObject => {
     },
   });
   // path 按照 24px 的进行绘制，然后进行缩放
-  path.setAttribute('origin', [0.5, 0.5]);
   path.scale(size / 24);
 
   rect.appendChild(path);

--- a/src/ui/toolbox/items/reload.ts
+++ b/src/ui/toolbox/items/reload.ts
@@ -9,6 +9,7 @@ export const reload = ({ size = 24, stroke = '#363636' }): DisplayObject => {
       y: 0,
       lineWidth: 1,
       stroke,
+      transformOrigin: 'center',
       path: [
         ['M', 3, 10.5],
         ['A', r, r - 1, 0, 0, 1, 21, 9.5],
@@ -24,7 +25,6 @@ export const reload = ({ size = 24, stroke = '#363636' }): DisplayObject => {
     },
   });
   // path 按照 24px 的进行绘制，然后进行缩放
-  path.setAttribute('origin', [0.5, 0.5]);
   path.scale(size / 24);
 
   rect.appendChild(path);

--- a/src/ui/toolbox/items/reset.ts
+++ b/src/ui/toolbox/items/reset.ts
@@ -9,6 +9,7 @@ export const reset = ({ size = 24, stroke = '#363636' }): DisplayObject => {
       y: 0,
       lineWidth: 1,
       stroke,
+      transformOrigin: 'center',
       path: [
         ['M', 3, 3],
         ['L', 21, 3],
@@ -22,7 +23,6 @@ export const reset = ({ size = 24, stroke = '#363636' }): DisplayObject => {
     },
   });
   // path 按照 24px 的进行绘制，然后进行缩放
-  path.setAttribute('origin', [0.5, 0.5]);
   path.scale(size / 24);
 
   rect.appendChild(path);

--- a/src/util/style.ts
+++ b/src/util/style.ts
@@ -1,6 +1,32 @@
 import { clone, deepMix, get } from '@antv/util';
+import type { TextStyleProps } from '@antv/g';
 import { STATE_LIST } from '../constant';
 import type { MixAttrs, StyleState } from '../types';
+
+/**
+ * 以下属性都是可继承的，这意味着没有显式定义（值为 unset）时，是需要从未来的祖先节点中计算得到的。
+ * 因此 Text 在创建之后立刻调用 getBounds 等方法获取包围盒是不准确的（例如 getShapeSpace 方法）。
+ *
+ * 目前 GUI 里这么做通常是为了布局。但理想的做法是使用布局属性（例如 BoxFlow 中的 margin / padding，Flex 布局的 flex 等），
+ * 正如在浏览器中我们很少使用 getBoundingClientRect 而更多使用 `display: block/flex/grids`，
+ * 这样可以避免手动计算（如何计算以及计算时机只有 浏览器/G 最清楚）。
+ *
+ * 暂时在布局实现前，先通过显式定义的值绕开该问题，当然这也放弃了继承特性（例如根节点上的 fontSize 修改也影响不到了）。
+ *
+ * 继承机制 & 默认值 @see https://g-next.antv.vision/zh/docs/api/css/inheritance
+ */
+export const TEXT_INHERITABLE_PROPS: Pick<
+  TextStyleProps,
+  'fontSize' | 'fontFamily' | 'fontWeight' | 'fontVariant' | 'fontStyle' | 'textAlign' | 'textBaseline'
+> = {
+  fontSize: '16px',
+  fontFamily: 'sans-serif',
+  fontWeight: 'normal',
+  fontVariant: 'normal',
+  fontStyle: 'normal',
+  textAlign: 'start',
+  textBaseline: 'alphabetic',
+};
 
 /**
  * 从带状态样式中返回移除了状态样式的默认样式


### PR DESCRIPTION
处于实现了样式系统，但还没实现布局的尴尬阶段。

## 继承属性

新版本实现了[样式系统](https://g-next.antv.vision/zh/docs/api/css/inheritance)，其中 Text 的一些属性例如 `fontSize` `fontWeight` 都是可继承属性，即用户未显式指定时值为 `unset`，需要加入文档后等待渲染引擎根据层次结构解析属性、计算 [computed value](https://g-next.antv.vision/zh/docs/api/css/css-properties-values-api#computed-value)，再应用布局算法得到最终使用的 [used value](https://g-next.antv.vision/zh/docs/api/css/css-properties-values-api#used-value)。

正如在 DOM API 中如下代码会返回一个空的 DOMRect，在加入文档甚至是浏览器 layout 前我们都无法获得正确的包围盒：

```js
const el = document.createElement('div');
el.innerHTML = 'text';
el.getBoundingClientRect(); // 空 DOMRect，top/left/width/height = 0
```

同样在 GUI 中也有类似的代码，例如创建一个 Text 后立即获取包围盒，用于其他元素的定位。由于 `fontWeight` 等影响包围盒的属性都是可继承的，且用户又未设置，因此此时包围盒无法计算：
```js
const temp = new Text({
  style: {
    ...textStyle,
    text: formattedText,
  },
});
// 文字包围盒的宽高
const { width: textWidth, height: textHeight } = getShapeSpace(temp);
```

同样与之类似的还有使用百分比的长度值：`rect.style.width = '50%'`，它加入不同的父节点就会有不同的宽度，在创建后的一刻完全无法预知自身的包围盒。

既然有这么多不确定性，在浏览器中我们是如何使用布局的呢？
我们似乎很少需要使用到 `getBoundingClientRect`，更多通过相对关系描述元素位置。即使需要用到，也通常在 mounted 之后使用：https://react-hooks.org/docs/useBoundingclientrect
得益于浏览器提供的各种布局（BlockFlow / Flex / Grid），我们可以在无需提前计算包围盒的情况下，也能完成布局任务。

因此在布局实现前，先通过显式定义的值绕开该问题，当然这也放弃了继承特性（例如根节点上的 fontSize 修改也影响不到了）。
在布局实现之后，上面的问题就可以直接使用 BlockFlow，`display: 'block'` 即可，容器内元素挨个排列，排不下就换行，元素间完全不需要感知邻居的包围盒。最终在 GUI 内应该看不到对于 `getBoundingClientRect / getBounds` 的调用。

## style.origin

当需要设置变换中心时，可以使用：
* CSS 同名属性 [transformOrigin](https://g-next.antv.vision/zh/docs/api/basic/display-object#transformorigin)。可以使用字面量避免手动计算
* [get/setOrigin](https://g-next.antv.vision/zh/docs/api/basic/display-object#%E8%AE%BE%E7%BD%AE%E7%BC%A9%E6%94%BE%E5%92%8C%E6%97%8B%E8%BD%AC%E4%B8%AD%E5%BF%83) 方法，需要手动计算

`origin` 并不是一个标准属性，其相对于 [anchor](https://g-next.antv.vision/zh/docs/api/basic/display-object#%E9%94%9A%E7%82%B9) 的定义也容易让人混乱。

## 体积

我得再想想办法，`limit-size 390 -> 400`像是每次小心翼翼把水龙头又拧开了一点。