### PR TITLE
chore: remove g-canvas/svg from deps to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/gui",
-  "version": "0.3.4-beta.2",
+  "version": "0.4.2",
   "description": "UI components for AntV G.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/gui",
-  "version": "0.3.4-beta.1",
+  "version": "0.3.4-beta.2",
   "description": "UI components for AntV G.",
   "license": "MIT",
   "main": "lib/index.js",
@@ -44,8 +44,6 @@
   "dependencies": {
     "@antv/dom-util": "^2.0.3",
     "@antv/g": "^5.0.21",
-    "@antv/g-canvas": "^1.0.20",
-    "@antv/g-svg": "^1.0.18",
     "@antv/matrix-util": "^3.0.4",
     "@antv/path-util": "^2.0.15",
     "@antv/scale": "^0.4.3",
@@ -58,6 +56,8 @@
     "@antv/g": "^5.0.1"
   },
   "devDependencies": {
+    "@antv/g-canvas": "^1.0.20",
+    "@antv/g-svg": "^1.0.18",
     "@antv/gatsby-theme-antv": "^1.1.8",
     "@antv/scale": "^0.4.6",
     "@babel/plugin-proposal-decorators": "^7.15.4",


### PR DESCRIPTION
`g-canvas/svg/webgl` 应该都是 `devDependencies`，对于 UI 组件库来说