### PR TITLE
fix(ui): x/y 不再是所有图形共有属性

### DIFF
--- a/__tests__/unit/ui/axis/arc-spec.ts
+++ b/__tests__/unit/ui/axis/arc-spec.ts
@@ -1,4 +1,4 @@
-import { Path, Group } from '@antv/g';
+import { Path, Group, PathCommand } from '@antv/g';
 import { Band as BandScale } from '@antv/scale';
 import { Arc, ArcAxisStyleProps } from '../../../../src';
 import { createCanvas } from '../../../utils/render';
@@ -52,8 +52,12 @@ describe('Arc axis', () => {
 
     it('Arc axis, ({ startAngle, endAngle })', () => {
       arc.update({ center: [400, 400], radius: 50 });
-      expect(axisLine.style.path![0]).toEqual(['M', arc.style.center[0], arc.style.center[1]]);
-      expect(axisLine.style.path![1]).toEqual(['L', arc.style.center[0] + arc.style.radius, arc.style.center[1]]);
+      expect((axisLine.style.path as PathCommand[])![0]).toEqual(['M', arc.style.center[0], arc.style.center[1]]);
+      expect((axisLine.style.path as PathCommand[])![1]).toEqual([
+        'L',
+        arc.style.center[0] + arc.style.radius,
+        arc.style.center[1],
+      ]);
     });
 
     it('Arc axis line, ({ axisLine: {} })', () => {

--- a/__tests__/unit/ui/crosshair/line-crosshair-spec.ts
+++ b/__tests__/unit/ui/crosshair/line-crosshair-spec.ts
@@ -34,9 +34,9 @@ canvas.appendChild(line);
 describe('line-crosshair', () => {
   test('basic', () => {
     // @ts-ignore
-    expect(line.shapesGroup.attr('x')).toBe(100);
-    // @ts-ignore
-    expect(line.shapesGroup.attr('y')).toBe(50);
+    const [x, y] = line.shapesGroup.getLocalPosition();
+    expect(x).toBe(100);
+    expect(y).toBe(50);
     // @ts-ignore
     expect(line.tagShape.attr('text')).toBe('123');
     // @ts-ignore
@@ -54,9 +54,9 @@ describe('line-crosshair', () => {
     await delay(20);
     // 水平移动只改变 x 坐标
     // @ts-ignore
-    expect(line.shapesGroup.attr('x')).toBe(200);
-    // @ts-ignore
-    expect(line.shapesGroup.attr('y')).toBe(50);
+    const [x, y] = line.shapesGroup.getLocalPosition();
+    expect(x).toBe(200);
+    expect(y).toBe(50);
   });
 
   test('horizontal', async () => {
@@ -66,10 +66,10 @@ describe('line-crosshair', () => {
     });
 
     // @ts-ignore
-    expect(line.shapesGroup.attr('x')).toBe(50);
+    let [x, y] = line.shapesGroup.getLocalPosition();
+    expect(x).toBe(50);
     // pointer y is 200
-    // @ts-ignore
-    expect(line.shapesGroup.attr('y')).toBe(200);
+    expect(y).toBe(200);
     // @ts-ignore
     expect(line.crosshairShape.attr('path')).toStrictEqual([['M', 0, 0], ['L', 350, 0], ['Z']]);
 
@@ -77,9 +77,9 @@ describe('line-crosshair', () => {
     await delay(20);
     // 水平移动只改变 y 坐标
     // @ts-ignore
-    expect(line.shapesGroup.attr('x')).toBe(50);
-    // @ts-ignore
-    expect(line.shapesGroup.attr('y')).toBe(250);
+    [x, y] = line.shapesGroup.getLocalPosition();
+    expect(x).toBe(50);
+    expect(y).toBe(250);
   });
 
   afterAll(() => {

--- a/__tests__/unit/ui/crosshair/polygon-crosshair-spec.ts
+++ b/__tests__/unit/ui/crosshair/polygon-crosshair-spec.ts
@@ -1,4 +1,4 @@
-import { Canvas } from '@antv/g';
+import { Canvas, PathCommand } from '@antv/g';
 import { Renderer } from '@antv/g-canvas';
 import { PolygonCrosshair } from '../../../../src';
 import { createDiv } from '../../../utils';
@@ -39,7 +39,7 @@ canvas.appendChild(polygon);
 describe('polygon-crosshair', () => {
   test('basic', async () => {
     // @ts-ignore
-    const path = polygon.crosshairShape.attr('path');
+    const path = polygon.crosshairShape.attr('path') as PathCommand[];
     // @ts-ignore
     polygon.points.forEach(([x, y], index) => {
       expect(x ** 2 + y ** 2).toBeCloseTo(1);
@@ -65,7 +65,7 @@ describe('polygon-crosshair', () => {
     polygon.setPointer([200, 100]);
     await delay(20);
     // @ts-ignore
-    const path = polygon.crosshairShape.attr('path');
+    const path = polygon.crosshairShape.attr('path') as PathCommand[];
     // @ts-ignore
     polygon.points.forEach(([x, y], index) => {
       const [px, py] = path![index].slice(1) as [number, number];

--- a/__tests__/unit/ui/legend/category.spec.ts
+++ b/__tests__/unit/ui/legend/category.spec.ts
@@ -24,11 +24,11 @@ describe('Category legend', () => {
     const category = new Category({ style: { items, padding: [2, 4], backgroundStyle: { fill: 'pink' } } });
     canvas.appendChild(category);
 
-    const background = category.querySelector('.legend-background')!;
+    const background = category.querySelector('.legend-background') as DisplayObject;
     const container = category.querySelector('.legend-container') as Group;
     expect(background.style.fill).toBe('pink');
-    expect(container.style.x).toBe(background.style.x + 4);
-    expect(container.style.y).toBe(background.style.y + 2);
+    expect(container.getLocalPosition()[0]).toBe(background.getLocalPosition()[0] + 4);
+    expect(container.getLocalPosition()[1]).toBe(background.getLocalPosition()[1] + 2);
     expect(container.getBBox().width).toBe(background.style.width - 8);
 
     category.destroy();

--- a/__tests__/unit/ui/page-navigator/index-spec.ts
+++ b/__tests__/unit/ui/page-navigator/index-spec.ts
@@ -133,21 +133,21 @@ describe('page navigator', () => {
     expect(width).toBeCloseTo(pageWidth);
     expect(height).toBeCloseTo(pageHeight);
     // 第1页
-    expect(pages.attr('x')).toBeCloseTo(0);
+    expect(pages.getLocalPosition()[0]).toBeCloseTo(0);
     // 第二页
     await pageNavigator.next().then((e) => {
       //
     });
-    expect(pages.attr('x')).toBeCloseTo(-pageWidth);
+    expect(pages.getLocalPosition()[0]).toBeCloseTo(-pageWidth);
     // 第三页
     await pageNavigator.goTo(3).then((e) => {
       //
     });
-    expect(pages.attr('x')).toBeCloseTo(-pageWidth * 2);
+    expect(pages.getLocalPosition()[0]).toBeCloseTo(-pageWidth * 2);
     // 第四页
     await pageNavigator.next().then((e) => {
       //
     });
-    expect(pages.attr('x')).toBeCloseTo(-pageWidth * 3);
+    expect(pages.getLocalPosition()[0]).toBeCloseTo(-pageWidth * 3);
   });
 });

--- a/__tests__/unit/ui/page-navigator/vertical-spec.ts
+++ b/__tests__/unit/ui/page-navigator/vertical-spec.ts
@@ -137,21 +137,21 @@ describe('vertical page navigator', () => {
     expect(height).toBeCloseTo(pageHeight);
 
     // 第1页
-    expect(pages.attr('y')).toBeCloseTo(0);
+    expect(pages.getLocalPosition()[1]).toBeCloseTo(0);
     // 第二页
     await pageNavigator.next().then((e) => {
       //
     });
-    expect(pages.attr('y')).toBeCloseTo(-pageHeight);
+    expect(pages.getLocalPosition()[1]).toBeCloseTo(-pageHeight);
     // 第三页
     await pageNavigator.goTo(3).then((e) => {
       //
     });
-    expect(pages.attr('y')).toBeCloseTo(-pageHeight * 2);
+    expect(pages.getLocalPosition()[1]).toBeCloseTo(-pageHeight * 2);
     // 第四页
     await pageNavigator.next().then((e) => {
       //
     });
-    expect(pages.attr('y')).toBeCloseTo(-pageHeight * 3);
+    expect(pages.getLocalPosition()[1]).toBeCloseTo(-pageHeight * 3);
   });
 });

--- a/__tests__/unit/ui/scrollbar/index-spec.ts
+++ b/__tests__/unit/ui/scrollbar/index-spec.ts
@@ -176,8 +176,9 @@ describe('scrollbar', () => {
 
     // @ts-ignore
     const track = scrollbar.trackShape;
-    expect(track.attr('x')).toBe(0);
-    expect(track.attr('y')).toBe(0);
+    const [x, y] = track.getLocalPosition();
+    expect(x).toBe(0);
+    expect(y).toBe(0);
   });
 });
 

--- a/__tests__/unit/ui/text/index-spec.ts
+++ b/__tests__/unit/ui/text/index-spec.ts
@@ -48,7 +48,7 @@ describe('text', () => {
       verticalAlign: 'top',
     });
     // @ts-ignore
-    const { x, y } = text.textShape.attributes;
+    const [x, y] = text.textShape.getLocalPosition();
     expect(x).toBe(0);
     expect(y).toBe(text.textHeight / 2);
   });

--- a/examples/chart-ui/poptip/demo/basic-poptip.ts
+++ b/examples/chart-ui/poptip/demo/basic-poptip.ts
@@ -23,8 +23,8 @@ const rect = new Rect({
 
 const circle = new Circle({
   style: {
-    x: 60,
-    y: 120,
+    cx: 60,
+    cy: 120,
     r: 25,
     fill: 'red',
   },

--- a/examples/chart-ui/poptip/demo/more-direction-poptip.ts
+++ b/examples/chart-ui/poptip/demo/more-direction-poptip.ts
@@ -33,8 +33,8 @@ const rect2 = new Rect({
 
 const circle = new Circle({
   style: {
-    x: 120,
-    y: 340,
+    cx: 120,
+    cy: 340,
     r: 25,
     fill: 'red',
   },

--- a/examples/chart-ui/poptip/demo/poptip-domStyles.ts
+++ b/examples/chart-ui/poptip/demo/poptip-domStyles.ts
@@ -13,8 +13,8 @@ const canvas = new Canvas({
 
 const circle = new Circle({
   style: {
-    x: 180,
-    y: 50,
+    cx: 180,
+    cy: 50,
     r: 25,
     fill: 'red',
   },

--- a/examples/chart-ui/tooltip/demo/basic-tooltip.ts
+++ b/examples/chart-ui/tooltip/demo/basic-tooltip.ts
@@ -17,8 +17,8 @@ new Array(10 ** 2).fill(Math.random() * 100).forEach((val, idx) => {
     new Circle({
       name: 'dot',
       style: {
-        x: ((idx % 10) + 1.5) * 50,
-        y: (Math.floor(idx / 10) + 1.5) * 50,
+        cx: ((idx % 10) + 1.5) * 50,
+        cy: (Math.floor(idx / 10) + 1.5) * 50,
         r: 10,
         fill: `rgb(${Array.from({ length: 3 }, () => {
           return Math.round((0.4 + Math.random() * 0.6) * 255);

--- a/examples/chart-ui/tooltip/demo/mini-tooltip.ts
+++ b/examples/chart-ui/tooltip/demo/mini-tooltip.ts
@@ -34,8 +34,8 @@ Array.from({ length: 300 }, () => {
   const dot = new Circle({
     name: 'scatter',
     style: {
-      x,
-      y,
+      cx: x,
+      cy: y,
       r,
       fill: '#f9bc2e',
     },

--- a/src/types/dependency.ts
+++ b/src/types/dependency.ts
@@ -1,5 +1,5 @@
 export type {
-  BaseStyleProps as ShapeAttrs,
+  BaseCustomElementStyleProps as ShapeAttrs,
   DisplayObject,
   DisplayObjectConfig,
   CircleStyleProps as CircleProps,

--- a/src/ui/legend/continuousIndicator.ts
+++ b/src/ui/legend/continuousIndicator.ts
@@ -5,13 +5,13 @@ import {
   PathCommand,
   CustomElement,
   DisplayObjectConfig,
-  BaseStyleProps,
+  BaseCustomElementStyleProps,
   TextStyleProps,
 } from '@antv/g';
 import { clamp } from '@antv/util';
 import { deepAssign } from '../../util';
 
-type IndicatorStyleProps = BaseStyleProps & {
+type IndicatorStyleProps = BaseCustomElementStyleProps & {
   position: 'top' | 'right';
   textStyle?: TextStyleProps;
 };

--- a/src/ui/timeline/slider-axis.ts
+++ b/src/ui/timeline/slider-axis.ts
@@ -195,7 +195,7 @@ export class SliderAxis extends GUI<Required<SliderAxisCfg>> {
     }
     if (newEndIdx <= currStartIdx) return;
     let stepLength = (dataPerStep / (timeData.length - 1)) * this.actualLength;
-    const endHandleX = (this.endHandleShape?.attributes.x as number) + (this.selectionShape.attributes.x as number);
+    const endHandleX = (this.endHandleShape?.attributes.cx as number) + (this.selectionShape.attributes.x as number);
     if (endHandleX + stepLength > length - (backgroundStyle.radius as number)) {
       stepLength = -endHandleX + length - (backgroundStyle.radius as number);
     }
@@ -211,11 +211,11 @@ export class SliderAxis extends GUI<Required<SliderAxisCfg>> {
     );
     if (this.animation) {
       this.animation.onframe = () => {
-        this.endHandleShape?.attr({ x: this.selectionShape.parsedStyle.width?.value as number });
+        this.endHandleShape?.attr({ cx: this.selectionShape.parsedStyle.width?.value as number });
       };
       this.animation.onfinish = () => {
         const newSelection = this.calculateSelection() as [string, string];
-        this.endHandleShape?.attr({ x: this.selectionShape.parsedStyle.width?.value as number });
+        this.endHandleShape?.attr({ cx: this.selectionShape.parsedStyle.width?.value as number });
         this.attr({ selection: newSelection });
         isFunction(onSelectionChange) && onSelectionChange([selection[0], timeData[newEndIdx].date]);
       };
@@ -347,7 +347,7 @@ export class SliderAxis extends GUI<Required<SliderAxisCfg>> {
       const newStartIdx = startIdx + dataPerStep;
       if (newStartIdx < 0) return;
       let stepLength = (dataPerStep / (timeData.length - 1)) * this.actualLength;
-      const endHandleX = (this.endHandleShape?.attributes.x as number) + (this.selectionShape.attributes.x as number);
+      const endHandleX = (this.endHandleShape?.attributes.cx as number) + (this.selectionShape.attributes.x as number);
       if (endHandleX + stepLength > length - (backgroundStyle.radius as number)) {
         stepLength = -endHandleX + length - (backgroundStyle.radius as number);
       }
@@ -512,7 +512,7 @@ export class SliderAxis extends GUI<Required<SliderAxisCfg>> {
               width: newLength,
             });
             this.endHandleShape!.attr({
-              x: newLength,
+              cx: newLength,
             });
             const startHandleX = (this.selectionShape.getAttribute('x') as number) - radius; // 相对背景的x坐标
             let nearestTimeDataId = Math.round((startHandleX / this.actualLength) * (timeData.length - 1));
@@ -528,7 +528,7 @@ export class SliderAxis extends GUI<Required<SliderAxisCfg>> {
               width: newLength,
             });
             this.endHandleShape!.attr({
-              x: newLength,
+              cx: newLength,
             });
             const endHandleX = (this.selectionShape.getAttribute('x') as number) + newLength - radius;
             let nearestTimeDataId = Math.round((endHandleX / this.actualLength) * (timeData.length - 1));
@@ -639,14 +639,14 @@ export class SliderAxis extends GUI<Required<SliderAxisCfg>> {
         this.startHandleShape = new Circle({
           style: {
             ...handleStyle,
-            y: (this.selectionShape.getAttribute('height') as number) / 2,
+            cy: (this.selectionShape.getAttribute('height') as number) / 2,
           },
         });
         this.endHandleShape = new Circle({
           style: {
             ...handleStyle,
-            x: selectionLength,
-            y: (this.selectionShape.getAttribute('height') as number) / 2,
+            cx: selectionLength,
+            cy: (this.selectionShape.getAttribute('height') as number) / 2,
           },
         });
         this.selectionShape.appendChild(this.startHandleShape);

--- a/src/ui/timeline/speedcontrol.ts
+++ b/src/ui/timeline/speedcontrol.ts
@@ -82,8 +82,7 @@ export class SpeedControl extends GUI<Required<SpeedControlCfg>> {
     for (let i = 0; i < this.lineShapes.length; i += 1) {
       const onClick = (event: any) => {
         const line = event.target as Path;
-        const { y } = line.attributes;
-        this.triangleShape?.setAttribute('y', (y as number) - 2);
+        this.triangleShape?.setLocalPosition(this.triangleShape?.getLocalPosition()[0], line.getLocalPosition()[1] - 2);
         this.labelShape?.update({ text: formatter(speeds[i]) });
         this.setAttribute('currentSpeedIdx', i);
         isFunction(onSpeedChange) && onSpeedChange(i);
@@ -96,14 +95,13 @@ export class SpeedControl extends GUI<Required<SpeedControlCfg>> {
     if (!this.lineShapes) return;
     const { currentSpeedIdx } = this.attributes;
     const line = this.lineShapes[currentSpeedIdx];
-    const { y } = line.attributes;
     this.triangleShape = new Path({
       style: {
         fill: '#8c8c8c',
         path: this.trianglePath(0, 0) as PathCommand[],
       },
     });
-    this.triangleShape.setAttribute('y', (y as number) - 2);
+    this.triangleShape.setLocalPosition(this.triangleShape?.getLocalPosition()[0], line.getLocalPosition()[1] - 2);
     this.triangleShape.translateLocal(0);
     this.appendChild(this.triangleShape);
   }
@@ -132,7 +130,7 @@ export class SpeedControl extends GUI<Required<SpeedControlCfg>> {
   private createLabel() {
     const { width, speeds, label, spacing, currentSpeedIdx } = this.attributes;
     const lastLine = this.lineShapes && this.lineShapes[(this.lineShapes?.length as number) - 1];
-    const lastLineY = lastLine?.attributes.y as number;
+    const lastLineY = lastLine?.getLocalPosition()[1]!;
     let restSpacing = width - 10 - spacing;
     restSpacing = restSpacing > 0 ? restSpacing : 0;
     this.labelShape = new Text({

--- a/src/ui/toolbox/items/download.ts
+++ b/src/ui/toolbox/items/download.ts
@@ -5,8 +5,6 @@ export const download = ({ size = 24, stroke = '#363636' }): DisplayObject => {
   const c = 8.5;
   const path = new Path({
     style: {
-      x: 0,
-      y: 0,
       lineWidth: 1,
       stroke,
       transformOrigin: 'center',

--- a/src/ui/toolbox/items/reload.ts
+++ b/src/ui/toolbox/items/reload.ts
@@ -5,8 +5,6 @@ export const reload = ({ size = 24, stroke = '#363636' }): DisplayObject => {
   const r = 8;
   const path = new Path({
     style: {
-      x: 0,
-      y: 0,
       lineWidth: 1,
       stroke,
       transformOrigin: 'center',

--- a/src/ui/toolbox/items/reset.ts
+++ b/src/ui/toolbox/items/reset.ts
@@ -5,8 +5,6 @@ export const reset = ({ size = 24, stroke = '#363636' }): DisplayObject => {
   const c = Math.sqrt(9);
   const path = new Path({
     style: {
-      x: 0,
-      y: 0,
       lineWidth: 1,
       stroke,
       transformOrigin: 'center',


### PR DESCRIPTION
与 SVG 保持一致，不同图形对于 “位置” 的定义不同，而且 `x/y` 有特定含义，不能作为所有图形的共有属性，例如：
- Circle / Ellipse 应当使用 [cx/cy](https://g-next.antv.vision/zh/docs/api/basic/circle#cx)
- Path / Line 等都有各自定义方式，`x/y` 对它们也无意义
- Rect / Group / Image / HTML / CustomElement 可以使用 `x/y`，含义为左上角顶点

之前对于该属性的误用会造成大量非预期的结果，因此是一个 Breaking Change（v5.1.1）
详见：https://g-next.antv.vision/zh/docs/api/basic/display-object#%E4%BD%8D%E7%BD%AE

## x/y -> cx/cy

因此需要将 Circle / Ellipse 的 `x/y` 修改为 `cx/cy`：
```js
new Circle({
  style: {
    // x: 0,
    // y: 0,
    cx: 0,
    cy: 0,
  }
});

// circle.style.x = 0;
circle.style.cx = 0;
```

## 获取 / 设置局部坐标系下位置

当希望获取图形在局部坐标系下的位置时，永远应当使用 [getLocalPosition](https://g-next.antv.vision/zh/docs/api/basic/display-object#%E5%B9%B3%E7%A7%BB)，而非 `x/y`，除上面那点之外原因有二：

* 即使是 Rect 这样支持 `x/y` 的图形，当用户未设置 `x` 时，`rect.attributes.x / rect.getAttribute('x')` 应为空字符串（同 DOM API 行为），虽然经过解析计算后会使用默认值 `0` 渲染
* 图形的位置会受到 [transform](https://g-next.antv.vision/zh/docs/api/basic/display-object#transform) 这样的属性影响

```js
// rect.attributes.x;
// rect.style.x;
const [x, y] = rect.getLocalPosition();
```

当希望设置图形在局部坐标系下的位置时，可以使用：
* 命令式变换方法，例如设置绝对位置的 `setLocalPosition()`，或者移动相对距离的 `translateLocal()`
* 声明式方式，使用 [transform](https://g-next.antv.vision/zh/docs/api/basic/display-object#transform) ，同 CSS Transform

当然如果图形支持 `x/y`，例如 Rect：
```js
rect.style.x = 100;
rect.style.x = '100px';
rect.setAttribute('x', 100);
rect.setAttribute('x', '100px');
```