### PR TITLE
fix: replace geometry-bounds-changed event with bounds-changed

### DIFF
--- a/src/ui/legend/continuousIndicator.ts
+++ b/src/ui/legend/continuousIndicator.ts
@@ -98,7 +98,7 @@ export class Indicator extends CustomElement<IndicatorStyleProps> {
   }
 
   private bindEvents() {
-    this.text.addEventListener(ElementEvent.GEOMETRY_BOUNDS_CHANGED, () => {
+    this.text.addEventListener(ElementEvent.BOUNDS_CHANGED, () => {
       this.updateBackground();
     });
   }


### PR DESCRIPTION
使用 `BOUNDS_CHANGED` 事件代替。原因是 G 移除了 `GEOMETRY_CHANGED` 事件，过于频繁的触发导致性能问题。