### PR TITLE
fix(timeline): 修复 timeline 中的 SpeedControl 传入 type 非 Shape 和 g 的时候位置失…

### DIFF
--- a/src/ui/timeline/speedcontrol.ts
+++ b/src/ui/timeline/speedcontrol.ts
@@ -27,7 +27,6 @@ export class SpeedControl extends CustomElement<StyleProps> {
   public static tag = 'speed-control';
 
   public static defaultOptions: DisplayObjectConfig<StyleProps> = {
-    type: SpeedControl.tag,
     style: DEFAULT_STYLE,
   };
 


### PR DESCRIPTION
- [x] 原因为 Group 传入 type 不是 Shape 或 'g' 这样的时候， 位置参数失效的问题

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/65594180/182804298-9eade774-b448-437d-9f07-15fd7eb81520.png) | ![image](https://user-images.githubusercontent.com/65594180/182803943-19b25b7d-9d37-4f36-891e-d279fb4ce4c4.png) |