### PR TITLE
style: remove default itemMarkerFill color

### DIFF
--- a/__tests__/integration/charts/bugs/category-give-shape-1.ts
+++ b/__tests__/integration/charts/bugs/category-give-shape-1.ts
@@ -25,6 +25,7 @@ export const BugCategoryWithShape1 = () => {
         height,
         gridCol: 10,
         gridRow: 10,
+        itemMarkerFill: '#d3d2d3',
         data: new Array(10).fill(0).map((d, i) => ({
           label: `label-${i}`,
           value: `value-${i}`,

--- a/__tests__/integration/charts/bugs/category-give-shape-2.ts
+++ b/__tests__/integration/charts/bugs/category-give-shape-2.ts
@@ -27,6 +27,7 @@ export const BugCategoryWithShape2 = () => {
         height,
         gridCol: 10,
         gridRow: 10,
+        itemMarkerFill: '#d3d2d3',
         data: new Array(20).fill(0).map((d, i) => ({
           label: `label-${i}`,
           value: `value-${i}`,

--- a/__tests__/integration/charts/bugs/category-give-shape-3.ts
+++ b/__tests__/integration/charts/bugs/category-give-shape-3.ts
@@ -13,6 +13,7 @@ export const BugCategoryWithShape3 = () => {
         height: 300,
         gridRow: undefined,
         gridCol: 1,
+        itemMarkerFill: '#d3d2d3',
         data: [
           { label: 'Under 5 Years' },
           { label: '5 to 13 Years' },

--- a/__tests__/integration/charts/bugs/category-items-update-2.ts
+++ b/__tests__/integration/charts/bugs/category-items-update-2.ts
@@ -14,6 +14,7 @@ export const BugCategoryItemsUpdate2 = () => {
         gridCol: 3,
         layout: 'grid',
         data: flowItemData,
+        itemMarkerFill: '#d3d2d3',
         itemLabelFill: 'green',
         itemValueFill: 'green',
         colPadding: 10,

--- a/__tests__/integration/charts/bugs/category-items-update-3.ts
+++ b/__tests__/integration/charts/bugs/category-items-update-3.ts
@@ -15,6 +15,7 @@ export const BugCategoryItemsUpdate3 = () => {
         gridCol: 3,
         layout: 'grid',
         data: flowItemData,
+        itemMarkerFill: '#d3d2d3',
         itemLabelFill: 'green',
         itemValueFill: 'green',
         colPadding: 10,

--- a/__tests__/integration/charts/bugs/category-label-display.ts
+++ b/__tests__/integration/charts/bugs/category-label-display.ts
@@ -32,6 +32,7 @@ export const BugCategoryLabelDisplay = () => {
         titleFontSize: 12,
         titleFontWeight: 'bold',
         titleFillOpacity: 1,
+        itemMarkerFill: '#d3d2d3',
         itemMarkerFillOpacity: 1,
         itemMarkerD: [['M', 0, 4], ['A', 4, 4, 0, 1, 0, 8, 4], ['A', 4, 4, 0, 1, 0, 0, 4], ['Z']],
       },

--- a/__tests__/integration/charts/bugs/category-update-3.ts
+++ b/__tests__/integration/charts/bugs/category-update-3.ts
@@ -15,6 +15,7 @@ export const BugCategoryUpdate3 = () => {
         gridCol: 3,
         data: flowItemData,
         titleText: 'Legend Title',
+        itemMarkerFill: '#d3d2d3',
       },
     })
   );

--- a/__tests__/integration/charts/bugs/category-update-4.ts
+++ b/__tests__/integration/charts/bugs/category-update-4.ts
@@ -15,6 +15,7 @@ export const BugCategoryUpdate4 = () => {
         gridCol: 3,
         data: flowItemData,
         titleText: 'Legend Title',
+        itemMarkerFill: '#d3d2d3',
       },
     })
   );

--- a/__tests__/integration/charts/legend/category-items-5.ts
+++ b/__tests__/integration/charts/legend/category-items-5.ts
@@ -13,6 +13,7 @@ export const CategoryItems5 = () => {
         orient: 'horizontal',
         gridRow: 2,
         gridCol: 8,
+        itemMarkerFill: '#d3d2d3',
         data: createItemData(20).map(({ value, ...rest }) => ({ ...rest })),
       },
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/gui",
-  "version": "0.4.3-alpha.70",
+  "version": "0.4.3-alpha.71",
   "description": "UI components for AntV G.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/ui/legend/category/item.ts
+++ b/src/ui/legend/category/item.ts
@@ -69,7 +69,6 @@ const CLASS_NAMES = classNames(
 const DEFAULT_ITEM_CFG: Partial<CategoryItemStyleProps> = {
   span: [1, 1],
   marker: () => new Circle({ style: { r: 6 } }),
-  markerFill: '#d3d2d3',
   markerSize: 10,
   labelFill: '#646464',
   valueFill: '#646464',


### PR DESCRIPTION
设置默认的 itemMarkerFill 之后会导致 G2 中图例 maker 存在默认颜色，不方便做镂空样式
修改后 G2 图例效果：
<img width="215" alt="image" src="https://user-images.githubusercontent.com/25787943/216514003-1a2e944b-e738-4b17-baac-4eb6d0c54fff.png">
<img width="210" alt="image" src="https://user-images.githubusercontent.com/25787943/216514008-d854c43f-0bcb-40bc-95b1-b45510fac08a.png">
