### PR TITLE
fix: prevent overriding destroy method in GUI

### DIFF
--- a/src/core/gui.ts
+++ b/src/core/gui.ts
@@ -29,6 +29,10 @@ export abstract class GUI<T extends Record<string, any>> extends CustomElement<T
     this.bindEvents(this.attributes, this);
   }
 
+  disconnectedCallback(): void {
+    this._offscreen.destroy();
+  }
+
   public update(attr: PartialStyleProps<T> = {}, animate?: GenericAnimation) {
     this.attr(deepAssign({}, this.attributes, attr));
     this.attr(getPrimitiveAttributes(this.attributes.style) as any);
@@ -37,12 +41,6 @@ export abstract class GUI<T extends Record<string, any>> extends CustomElement<T
 
   public clear() {
     this.removeChildren();
-  }
-
-  public destroy() {
-    this.removeAllEventListeners();
-    this.removeChildren();
-    this.remove();
   }
 
   attributeChangedCallback() {}


### PR DESCRIPTION
测试例子是绘制 1000 个 Button，然后调用 `canvas.destroyChildren()` 清空画布。发现有 1000 个 Group（这里的 `i`）未被销毁。

<img width="438" alt="截屏2023-02-24 下午3 35 57" src="https://user-images.githubusercontent.com/3608471/221119597-a58f24d1-6ae3-4470-8cca-99afe0e7883b.png">

Debug 了一下发现存在两个内存泄漏的点。

GUI 继承自 CustomElement，因此不能覆盖 `destroy` 方法（实在要的话也要调用下 `super.destroy()`），如果需要做类似资源清理工作，推荐在 `disconnectedCallback` 中写。否则会导致 G 的 destroy 方法无法执行，对象引用无法完全释放。

但去掉后仍然存在泄漏情况，原因是每个 GUI 组件都会默认创建一个 Group（offscreen），但在 `ifShow` 逻辑中根据可见性会 remove 掉，此时这个 Group 就成了一个“孤悬”的图形，它没有父节点因此在调用 GUI 组件本身的 destroy 时无法被销毁。所以在销毁时需要手动销毁掉。
```js
// GUI.ts
disconnectedCallback(): void {
  this._offscreen.destroy();
}
```

修改后重新度量可以发现这 1000 个 Group 可以被成功回收了：

<img width="513" alt="截屏2023-02-24 下午3 40 59" src="https://user-images.githubusercontent.com/3608471/221120560-fcc12097-2457-4133-85ff-c3e9a185dda6.png">

提供了如下方法获取当前对象池中所有未被销毁的图形，这样不借助 Memory 工具也能随时粗略排查因未销毁 DisplayObject 导致的内存泄漏问题：

```js
import { runtime } from '@antv/g';

// 清空画布
canvas.destroyChildren();
// 应该只留下根节点，有其他图形说明未销毁成功，即存在内存泄漏情况
runtime.displayObjectPool.getAll(); // [Group, ...]
```