### PR TITLE
chore: fix module config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@antv/gui",
-  "version": "0.5.0-alpha.15",
+  "version": "0.5.0-alpha.16",
   "description": "UI components for AntV G.",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "src/index.ts",
+  "module": "esm/index.js",
   "unpkg": "dist/gui.min.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
之前 link 开发改了 package.json 里的 module 配置，导致外部安装失败