### PR TITLE
feat: add autoFitLabel config to support disable auto fit label position

### DIFF
--- a/src/ui/slider/index.ts
+++ b/src/ui/slider/index.ts
@@ -104,6 +104,7 @@ export class Slider extends GUI<SliderStyleProps> {
       handleSpacing: 2,
       orientation: 'horizontal',
       padding: 0,
+      autoFitLabel: true,
       scrollable: true,
       selectionCursor: 'move',
       selectionFill: '#5B8FF9',
@@ -301,18 +302,16 @@ export class Slider extends GUI<SliderStyleProps> {
    * @returns
    */
   private calcHandleText(handleType: HandleType) {
-    const { orientation, formatter } = this.attributes;
+    const { orientation, formatter, autoFitLabel } = this.attributes;
     const handleStyle = subStyleProps(this.attributes, 'handle');
     const labelStyle = subStyleProps(handleStyle, 'label');
     const { spacing } = handleStyle;
     const size = this.getHandleSize();
     const values = this.clampValues();
 
-    // 相对于获取两端可用空间
-    const { width: iW, height: iH } = this.availableSpace;
-    const { x: fX, y: fY, width: fW, height: fH } = this.calcMask();
     const value = handleType === 'start' ? values[0] : values[1];
     const text = formatter(value);
+
     const temp = new Text({
       style: {
         ...labelStyle,
@@ -323,8 +322,16 @@ export class Slider extends GUI<SliderStyleProps> {
     const { width: textWidth, height: textHeight } = temp.getBBox();
     temp.destroy();
 
+    if (!autoFitLabel) {
+      const finaleWidth = spacing + size + (orientation === 'horizontal' ? textWidth / 2 : 0);
+      return { text, [orientation === 'horizontal' ? 'x' : 'y']: handleType === 'start' ? -finaleWidth : finaleWidth };
+    }
+
     let x = 0;
     let y = 0;
+    // 相对于获取两端可用空间
+    const { width: iW, height: iH } = this.availableSpace;
+    const { x: fX, y: fY, width: fW, height: fH } = this.calcMask();
     if (orientation === 'horizontal') {
       const totalSpacing = spacing + size;
       const finalWidth = totalSpacing + textWidth / 2;

--- a/src/ui/slider/types.ts
+++ b/src/ui/slider/types.ts
@@ -23,6 +23,7 @@ export type SliderStyleProps = GroupStyleProps &
     scrollable?: boolean;
     showHandle?: boolean;
     showLabel?: boolean;
+    autoFitLabel?: boolean;
     slidable?: boolean;
     trackLength?: number;
     trackSize?: number;


### PR DESCRIPTION
* 新增 autoFitLabel 选项，默认为 `true`，为 `false` 是不会自动调整标签值位置，以避免边界情况出现重叠的问题

> 需要在两端留出足够的 padding，否则可能会显示不全， 参考Echarts
<img width="600" alt="image" src="https://user-images.githubusercontent.com/25787943/236598625-daca6b47-ab73-49f7-b5a5-da730cef0315.png">


https://github.com/antvis/G2/issues/4931
<img width="354" alt="image" src="https://user-images.githubusercontent.com/25787943/236598557-af6458cd-0046-4ffb-929e-e1e08c9d0cef.png">
