### PR TITLE
feat: add tooltip.template.prefixCls config

### DIFF
--- a/__tests__/integration/components/tooltip/tooltip-2.ts
+++ b/__tests__/integration/components/tooltip/tooltip-2.ts
@@ -48,6 +48,9 @@ export const Tooltip2 = () => {
           y: 80,
         },
         bounding: false,
+        template: {
+          prefixCls: 'g2-',
+        },
       },
     })
   );

--- a/src/ui/tooltip/constant.ts
+++ b/src/ui/tooltip/constant.ts
@@ -1,15 +1,17 @@
-export const CLASS_NAME = {
-  CONTAINER: 'tooltip',
-  TITLE: 'tooltip-title',
-  LIST: 'tooltip-list',
-  LIST_ITEM: 'tooltip-list-item',
-  NAME: 'tooltip-list-item-name',
-  MARKER: 'tooltip-list-item-marker',
-  NAME_LABEL: 'tooltip-list-item-name-label',
-  VALUE: 'tooltip-list-item-value',
-  CROSSHAIR_X: 'tooltip-crosshair-x',
-  CROSSHAIR_Y: 'tooltip-crosshair-y',
-};
+export function getClassNames(prefixCls: string = '') {
+  return {
+    CONTAINER: `${prefixCls}tooltip`,
+    TITLE: `${prefixCls}tooltip-title`,
+    LIST: `${prefixCls}tooltip-list`,
+    LIST_ITEM: `${prefixCls}tooltip-list-item`,
+    NAME: `${prefixCls}tooltip-list-item-name`,
+    MARKER: `${prefixCls}tooltip-list-item-marker`,
+    NAME_LABEL: `${prefixCls}tooltip-list-item-name-label`,
+    VALUE: `${prefixCls}tooltip-list-item-value`,
+    CROSSHAIR_X: `${prefixCls}tooltip-crosshair-x`,
+    CROSSHAIR_Y: `${prefixCls}tooltip-crosshair-y`,
+  };
+}
 
 const TEXT_OVERFLOW_STYLE = {
   overflow: 'hidden',
@@ -17,78 +19,81 @@ const TEXT_OVERFLOW_STYLE = {
   'text-overflow': 'ellipsis',
 };
 
-export const TOOLTIP_STYLE = {
-  [`.${CLASS_NAME.CONTAINER}`]: {
-    position: 'absolute',
-    visibility: 'visible',
-    // 'white-space': 'nowrap',
-    'z-index': 8,
-    transition:
-      'visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), ' +
-      'left 0.4s cubic-bezier(0.23, 1, 0.32, 1), ' +
-      'top 0.4s cubic-bezier(0.23, 1, 0.32, 1)',
-    'background-color': 'rgba(255, 255, 255, 0.96)',
-    'box-shadow': '0 6px 12px 0 rgba(0, 0, 0, 0.12)',
-    'border-radius': '4px',
-    color: 'rgba(0, 0, 0, 0.65)',
-    'font-size': '12px',
-    // 'font-family': ,
-    'line-height': '20px',
-    padding: '12px',
-    'min-width': '120px',
-    'max-width': '360px',
-    'font-family': 'Roboto-Regular',
-  },
-  [`.${CLASS_NAME.TITLE}`]: {
-    color: 'rgba(0, 0, 0, 0.45)',
-  },
-  [`.${CLASS_NAME.LIST}`]: {
-    margin: '0px',
-    'list-style-type': 'none',
-    padding: '0px',
-  },
-  [`.${CLASS_NAME.LIST_ITEM}`]: {
-    'list-style-type': 'none',
-    display: 'flex',
-    'line-height': '2em',
-    'align-items': 'center',
-    'justify-content': 'space-between',
-    'white-space': 'nowrap',
-  },
-  [`.${CLASS_NAME.MARKER}`]: {
-    width: '8px',
-    height: '8px',
-    'border-radius': '50%',
-    display: 'inline-block',
-    'margin-right': '4px',
-  },
-  [`.${CLASS_NAME.NAME}`]: {
-    display: 'flex',
-    'align-items': 'center',
-    'max-width': '216px',
-  },
-  [`.${CLASS_NAME.NAME_LABEL}`]: {
-    flex: 1,
-    ...TEXT_OVERFLOW_STYLE,
-  },
-  [`.${CLASS_NAME.VALUE}`]: {
-    display: 'inline-block',
-    float: 'right',
-    flex: 1,
-    'text-align': 'right',
-    'min-width': '28px',
-    'margin-left': '30px',
-    color: 'rgba(0, 0, 0, 0.85)',
-    ...TEXT_OVERFLOW_STYLE,
-  },
-  [`.${CLASS_NAME.CROSSHAIR_X}`]: {
-    position: 'absolute',
-    width: '1px',
-    'background-color': 'rgba(0, 0, 0, 0.25)',
-  },
-  [`.${CLASS_NAME.CROSSHAIR_Y}`]: {
-    position: 'absolute',
-    height: '1px',
-    'background-color': 'rgba(0, 0, 0, 0.25)',
-  },
-};
+export function getDefaultTooltipStyle(prefixCls: string = '') {
+  const CLASS_NAME = getClassNames(prefixCls);
+  return {
+    [`.${CLASS_NAME.CONTAINER}`]: {
+      position: 'absolute',
+      visibility: 'visible',
+      // 'white-space': 'nowrap',
+      'z-index': 8,
+      transition:
+        'visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), ' +
+        'left 0.4s cubic-bezier(0.23, 1, 0.32, 1), ' +
+        'top 0.4s cubic-bezier(0.23, 1, 0.32, 1)',
+      'background-color': 'rgba(255, 255, 255, 0.96)',
+      'box-shadow': '0 6px 12px 0 rgba(0, 0, 0, 0.12)',
+      'border-radius': '4px',
+      color: 'rgba(0, 0, 0, 0.65)',
+      'font-size': '12px',
+      // 'font-family': ,
+      'line-height': '20px',
+      padding: '12px',
+      'min-width': '120px',
+      'max-width': '360px',
+      'font-family': 'Roboto-Regular',
+    },
+    [`.${CLASS_NAME.TITLE}`]: {
+      color: 'rgba(0, 0, 0, 0.45)',
+    },
+    [`.${CLASS_NAME.LIST}`]: {
+      margin: '0px',
+      'list-style-type': 'none',
+      padding: '0px',
+    },
+    [`.${CLASS_NAME.LIST_ITEM}`]: {
+      'list-style-type': 'none',
+      display: 'flex',
+      'line-height': '2em',
+      'align-items': 'center',
+      'justify-content': 'space-between',
+      'white-space': 'nowrap',
+    },
+    [`.${CLASS_NAME.MARKER}`]: {
+      width: '8px',
+      height: '8px',
+      'border-radius': '50%',
+      display: 'inline-block',
+      'margin-right': '4px',
+    },
+    [`.${CLASS_NAME.NAME}`]: {
+      display: 'flex',
+      'align-items': 'center',
+      'max-width': '216px',
+    },
+    [`.${CLASS_NAME.NAME_LABEL}`]: {
+      flex: 1,
+      ...TEXT_OVERFLOW_STYLE,
+    },
+    [`.${CLASS_NAME.VALUE}`]: {
+      display: 'inline-block',
+      float: 'right',
+      flex: 1,
+      'text-align': 'right',
+      'min-width': '28px',
+      'margin-left': '30px',
+      color: 'rgba(0, 0, 0, 0.85)',
+      ...TEXT_OVERFLOW_STYLE,
+    },
+    [`.${CLASS_NAME.CROSSHAIR_X}`]: {
+      position: 'absolute',
+      width: '1px',
+      'background-color': 'rgba(0, 0, 0, 0.25)',
+    },
+    [`.${CLASS_NAME.CROSSHAIR_Y}`]: {
+      position: 'absolute',
+      height: '1px',
+      'background-color': 'rgba(0, 0, 0, 0.25)',
+    },
+  };
+}

--- a/src/ui/tooltip/index.ts
+++ b/src/ui/tooltip/index.ts
@@ -3,7 +3,7 @@ import { substitute } from '@antv/util';
 import { GUI } from '../../core';
 import { Group } from '../../shapes';
 import { applyStyleSheet, throttle } from '../../util';
-import { CLASS_NAME, TOOLTIP_STYLE } from './constant';
+import { getClassNames, getDefaultTooltipStyle } from './constant';
 import type { TooltipOptions, TooltipPosition, TooltipStyleProps } from './types';
 
 export type { TooltipStyleProps, TooltipOptions };
@@ -42,6 +42,8 @@ export class Tooltip extends GUI<TooltipStyleProps> {
   private element!: HTMLElement;
 
   constructor(options: TooltipOptions) {
+    const prefixCls = options.style?.template?.prefixCls;
+    const CLASS_NAME = getClassNames(prefixCls);
     super(options, {
       data: [],
       x: 0,
@@ -57,6 +59,7 @@ export class Tooltip extends GUI<TooltipStyleProps> {
       },
       bounding: null,
       template: {
+        prefixCls: '',
         container: `<div class="${CLASS_NAME.CONTAINER}"></div>`,
         title: `<div class="${CLASS_NAME.TITLE}"></div>`,
         item: `<li class="${CLASS_NAME.LIST_ITEM}" data-index={index}>
@@ -67,7 +70,7 @@ export class Tooltip extends GUI<TooltipStyleProps> {
         <span class="${CLASS_NAME.VALUE}" title="{value}">{value}</span>
       </li>`,
       },
-      style: TOOLTIP_STYLE,
+      style: getDefaultTooltipStyle(prefixCls),
     });
     this.initShape();
     this.render(this.attributes, this);
@@ -128,6 +131,7 @@ export class Tooltip extends GUI<TooltipStyleProps> {
    */
   private renderHTMLTooltipElement() {
     const { template, title, enterable, style, content } = this.attributes;
+    const CLASS_NAME = getClassNames(template.prefixCls);
     const container = this.element;
     this.element.style.pointerEvents = enterable ? 'auto' : 'none';
     if (content) this.renderCustomContent();

--- a/src/ui/tooltip/types.ts
+++ b/src/ui/tooltip/types.ts
@@ -47,6 +47,8 @@ export type TooltipStyleProps = GroupStyleProps & {
     | false;
   /* 模版 */
   template?: {
+    /** tooltip div classname 前缀 */
+    prefixCls?: string;
     /* 容器模版 */
     container?: string;
     title?: string;


### PR DESCRIPTION
在 tooltip 中增加 style.template.prefixCls 配置项，可以自定义 dom 的 classname 前缀。

- ref https://github.com/antvis/G2/issues/5065