### PR TITLE
chore: add declaration of no side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "esm",
     "dist"
   ],
+  "sideEffects": false,
   "scripts": {
     "dev": "vite",
     "clean": "rimraf lib esm dist",


### PR DESCRIPTION
在 G6 中使用时发现没有被 treeshaking，打包进了一些没有用到的组件：

<img width="781" alt="截屏2023-05-24 下午1 39 17" src="https://github.com/antvis/GUI/assets/3608471/41db29df-f3e1-45ed-936a-731986d86416">

在 package.json 中声明 `sideEffects: false` 后正常（99 -> 25 Kb gzip）：

<img width="853" alt="截屏2023-05-24 下午1 39 02" src="https://github.com/antvis/GUI/assets/3608471/2c59e9f2-9e99-46b0-87ba-586fc436bb9a">

