### PR TITLE
fix(animation): title

### DIFF
--- a/src/ui/axis/guides/labels.ts
+++ b/src/ui/axis/guides/labels.ts
@@ -257,7 +257,7 @@ export function renderLabels(
           }),
       (exit) =>
         exit.transition(function () {
-          const animation = fadeOut(this, animate.exit);
+          const animation = fadeOut(this.childNodes[0], animate.exit);
           onAnimateFinished(animation, () => select(this).remove());
           return animation;
         })

--- a/src/ui/axis/guides/ticks.ts
+++ b/src/ui/axis/guides/ticks.ts
@@ -114,7 +114,7 @@ export function renderTicks(
         }),
       (exit) =>
         exit.transition(function () {
-          const animation = fadeOut(this, animate.exit);
+          const animation = fadeOut(this.childNodes[0], animate.exit);
           onAnimateFinished(animation, () => this.remove());
           return animation;
         })

--- a/src/ui/axis/types.ts
+++ b/src/ui/axis/types.ts
@@ -63,6 +63,7 @@ export type LabelOverlapCfg =
 
 export type AxisTitleStyleProps = Omit<TitleStyleProps, 'position'> & {
   position: TitleStyleProps['position'] | 'start' | 'end';
+  direction: 'horizontal' | 'vertical';
 };
 
 export type AxisTruncateStyleProps = {


### PR DESCRIPTION
解决坐标轴更新的时候，title 位置不对的问题，具体的效果等发一个 GUI  的包，在 G2 里面看效果。

```js
// 主要问题是这个 50% 有问题，导致位置更新不对
const before = {
  titleTransform: 'translate(50%, 0) rotate(-90)'
}

// 和上面语义相同，内部计算大小
const after = {
  titleDirection: 'vertical'
}
```