### PR TITLE
feat(legend-continonus): set labelOverlap to hide by default

### DIFF
--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -111,6 +111,7 @@ export class Continuous extends GUI<ContinuousStyleProps> {
     /** adjust */
     this.adjustLabel();
     this.adjustHandles();
+    // this.adjustTitle();
   }
 
   private get range() {
@@ -341,6 +342,22 @@ export class Continuous extends GUI<ContinuousStyleProps> {
     this.setHandlePosition('end', max);
   }
 
+  private adjustTitle() {
+    const { titlePosition, orientation } = this.attributes;
+    const [title] = this.getElementsByClassName(CLASS_NAMES.title.name);
+    const handle: Handle = this.handlesGroup.select(`.${this.getHandleClassName('start')}`).node();
+    if (!title || !handle) return;
+    if (titlePosition !== 'top-left' || orientation !== 'horizontal') return;
+    const {
+      min: [handleX],
+    } = handle.getLocalBounds();
+    const {
+      min: [titleX],
+    } = title.getLocalBounds();
+    const diffX = handleX - titleX;
+    title.style.x = +(this.style.x || 0) + diffX;
+  }
+
   private cacheHandleBBox: DOMRect | null = null;
 
   private get handleBBox() {
@@ -473,7 +490,7 @@ export class Continuous extends GUI<ContinuousStyleProps> {
       labelFormatter,
     };
 
-    const finalLabelStyle = { ...style, ...functionStyle } as LinearAxisStyleProps;
+    const finalLabelStyle = { ...style, ...functionStyle, labelOverlap: [{ type: 'hide' }] } as LinearAxisStyleProps;
 
     this.label = container.maybeAppendByClassName(CLASS_NAMES.label, () => new Axis({ style: finalLabelStyle })).node();
     this.label.update(finalLabelStyle, false);


### PR DESCRIPTION
# Legend

- 连续比例尺默认使用 hide 来除了 labelOverlap 的问题。
- adjustTitle 有点别的问题，所以先注释掉。

## Before

![image](https://github.com/antvis/GUI/assets/49330279/8502d938-c943-4734-b564-24333341844f)

## After

![image](https://github.com/antvis/GUI/assets/49330279/eeaa98ea-c18f-48ff-9adf-44b8f1b5dcdc)
