### PR TITLE
fix(item): align center

### DIFF
--- a/src/ui/legend/category/item.ts
+++ b/src/ui/legend/category/item.ts
@@ -24,7 +24,7 @@ import {
   subStyleProps,
 } from '../../../util';
 
-type ItemMarkerStyle = { size?: number } & PathStyleProps;
+type ItemMarkerStyle = { size?: number; sizeMax?: number } & PathStyleProps;
 type ItemTextStyle = Omit<TextStyleProps, 'text'>;
 type ItemBackgroundStyle = Omit<RectStyleProps, 'width' | 'height'>;
 
@@ -100,14 +100,14 @@ export class CategoryItem extends GUI<CategoryItemStyleProps> {
   private get actualSpace() {
     const label = this.labelGroup;
     const value = this.valueGroup;
-    const { markerSize } = this.attributes;
+    const { markerSize, markerSizeMax = markerSize } = this.attributes;
     const { width: labelWidth, height: labelHeight } = label.node().getBBox();
     const { width: valueWidth, height: valueHeight } = value.node().getBBox();
     return {
       markerWidth: markerSize,
       labelWidth,
       valueWidth,
-      height: Math.max(markerSize, labelHeight, valueHeight),
+      height: Math.max(markerSize, markerSizeMax, labelHeight, valueHeight),
     };
   }
 


### PR DESCRIPTION
# Item Align

解决这个 PR：https://github.com/antvis/G2/pull/5320 里面提到的第二个问题。

- 问题原因：item 只会根据自己的高度计算大小并且调整位置。
- 解决办法：G2 层传入 marker 的最大高度：itemMarkerSizeMax 给 GUI 消费，用户获得实际的高度。

## Before

<img src="https://github.com/antvis/GUI/assets/49330279/aff6c4b0-bee3-4dda-a525-9ab9dd3e3b17" width=640 />

## After

<img src="https://github.com/antvis/GUI/assets/49330279/8bb6ebcd-0eea-4b6d-b4a7-0852335bdc21" width=640 />
