### PR TITLE
fix: legend continuous

### DIFF
--- a/__tests__/integration/canvas.ts
+++ b/__tests__/integration/canvas.ts
@@ -1,8 +1,8 @@
+import * as fs from 'fs';
 import type { DisplayObject } from '@antv/g';
 import { Canvas, CanvasEvent } from '@antv/g';
 import { Renderer } from '@antv/g-canvas';
 import { createCanvas } from 'canvas';
-import * as fs from 'fs';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
 

--- a/__tests__/performance/server.ts
+++ b/__tests__/performance/server.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
-import cors from 'cors';
 import path from 'path';
-import express from 'express';
 import util from 'util';
+import cors from 'cors';
+import express from 'express';
 
 const exec = util.promisify(require('child_process').exec);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/gui",
-  "version": "0.5.0-alpha.25",
+  "version": "0.5.0-alpha.27",
   "description": "UI components for AntV G.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/ui/legend/continuous.ts
+++ b/src/ui/legend/continuous.ts
@@ -115,8 +115,8 @@ export class Continuous extends GUI<ContinuousStyleProps> {
   }
 
   private get range() {
-    const { data } = this.attributes;
-    return getMinMax(data);
+    const { data, domain } = this.attributes;
+    return domain ? { min: domain[0], max: domain[1] } : getMinMax(data);
   }
 
   private get ribbonScale() {

--- a/src/ui/legend/types.ts
+++ b/src/ui/legend/types.ts
@@ -52,6 +52,7 @@ export type ContinuousStyleProps = LegendBaseStyleProps &
   PrefixStyleProps<Partial<Omit<RibbonStyleProps, 'orientation' | 'range' | 'partition' | 'length'>>, 'ribbon'> &
   Partial<Pick<RibbonStyleProps, 'color' | 'block' | 'type'>> & {
     data: ContinuousDatum[];
+    domain?: [number, number];
     defaultValue?: [number, number];
     height: number;
     showHandle?: boolean;

--- a/src/ui/legend/utils.ts
+++ b/src/ui/legend/utils.ts
@@ -1,5 +1,4 @@
 import { Marker } from '../marker';
-import { toPrecision } from '../../util';
 
 /**
  * 将值转换至步长tick上
@@ -105,7 +104,7 @@ export function getSafetySelections(
   }
 
   // 保留小数
-  return [toPrecision(startVal, precision), toPrecision(endVal, precision)];
+  return [startVal, endVal];
 }
 
 export function ifHorizontal<T>(orientation: string = 'horizontal', a: T, b: T): T {

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -2,9 +2,7 @@
  * 保留x位小数
  */
 export function toPrecision(num: number, precision: number) {
-  const result = 10 ** precision;
-  // eslint-disable-next-line
-  return ~~(num * result) / result;
+  return +num.toPrecision(precision);
 }
 
 /**


### PR DESCRIPTION
- **内容**：修复 G2 添加连续的 legendFilter 交互时候存在的问题。
- **注意**：不是从 master checkout 的分支，因为 master 分支是新主题的分支，但是目前 G2 新主题还没有接入。这个 PR 合并之后，会基于目标分支 0.5.0-alpha.27 发布 0.5.0-alpha.27 版本，并且在 G2 锁定该版本。等主题接入之后再把 0.5.0-alpha.27 分支合并入 master 分支，并且发布 0.5.0-alpha.28 版本。
- **修复问题**：去掉 `toPrecision` 方法。

```js
function toPrecision(num, precision) {
  const result = 10 ** precision;
  return ~~(num * result) / result;
}

// 存在精度问题！！！
toPrecision(3700000, 4); // -165470.5664
```