### PR TITLE
fix(compile): Module not found bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,14 @@
       "types": "./lib/index.d.ts",
       "import": "./esm/index.js",
       "require": "./lib/index.js"
-    }
+    },
+    "./esm": "./esm/index.js",
+    "./lib": "./lib/index.js",
+    "./esm/*.js": "./esm/*.js",
+    "./lib/*.js": "./lib/*.js",
+    "./esm/*": "./esm/*.js",
+    "./lib/*": "./lib/*.js",
+    "./*": "./*"
   },
   "files": [
     "src",


### PR DESCRIPTION
跟g2一样的pr，解决当用户导出指定模块属性找不到模块bug的问题
g2 pr https://github.com/antvis/G2/pull/5470
g2 issue  https://github.com/antvis/G2/issues/5466